### PR TITLE
Potential fix for code scanning alert no. 79: Potentially unsafe quoting

### DIFF
--- a/pkg/apis/flowcontrol/validation/validation.go
+++ b/pkg/apis/flowcontrol/validation/validation.go
@@ -386,7 +386,8 @@ func ValidateIfMandatoryPriorityLevelConfigurationObject(pl *flowcontrol.Priorit
 	// sides of this comparison are intended to ultimately
 	// come from the same code.
 	if !apiequality.Semantic.DeepEqual(pl.Spec, mand.Spec) {
-		allErrs = append(allErrs, field.Invalid(fldPath, pl.Spec, fmt.Sprintf("spec of '%s' must equal the fixed value", pl.Name)))
+		escapedName := strings.ReplaceAll(pl.Name, "'", "\\'")
+		allErrs = append(allErrs, field.Invalid(fldPath, pl.Spec, fmt.Sprintf("spec of '%s' must equal the fixed value", escapedName)))
 	}
 	return allErrs
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/79](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/79)

To fix the issue, we need to ensure that any single quotes in `pl.Name` are properly escaped before embedding it in the string. This can be achieved using `strings.ReplaceAll` to replace single quotes with escaped single quotes (`\'`). This approach ensures that the constructed string remains valid and avoids potential issues with malformed error messages.

The fix involves modifying the `fmt.Sprintf` call on line 389 to sanitize `pl.Name` before embedding it in the string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
