### PR TITLE
Potential fix for code scanning alert no. 77: Potentially unsafe quoting

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -119,8 +119,9 @@ func ValidateHasLabel(meta metav1.ObjectMeta, fldPath *field.Path, key, expected
 		return allErrs
 	}
 	if actualValue != expectedValue {
+		escapedValue := strings.ReplaceAll(expectedValue, "'", "\\'")
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("labels").Key(key), meta.Labels,
-			fmt.Sprintf("must be '%s'", expectedValue)))
+			fmt.Sprintf("must be '%s'", escapedValue)))
 	}
 	return allErrs
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/77](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/77)

To fix the issue, we need to ensure that any single quotes in the `expectedValue` variable are properly escaped before embedding it into the single-quoted string literal. This can be achieved using the `strings.ReplaceAll` function to replace single quotes (`'`) with escaped single quotes (`\'`). This approach ensures that the error message remains well-formed regardless of the content of `expectedValue`.

The fix involves modifying the `fmt.Sprintf` call on line 123 to escape single quotes in `expectedValue` before embedding it into the string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
