### PR TITLE
Potential fix for code scanning alert no. 78: Potentially unsafe quoting

### DIFF
--- a/pkg/apis/flowcontrol/validation/validation.go
+++ b/pkg/apis/flowcontrol/validation/validation.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	flowcontrolv1beta1 "k8s.io/api/flowcontrol/v1beta1"
@@ -89,7 +90,7 @@ func ValidateFlowSchema(fs *flowcontrol.FlowSchema) field.ErrorList {
 		// sides of this comparison are intended to ultimately
 		// come from the same code.
 		if !apiequality.Semantic.DeepEqual(fs.Spec, mand.Spec) {
-			allErrs = append(allErrs, field.Invalid(specPath, fs.Spec, fmt.Sprintf("spec of '%s' must equal the fixed value", fs.Name)))
+			allErrs = append(allErrs, field.Invalid(specPath, fs.Spec, fmt.Sprintf("spec of %s must equal the fixed value", strconv.Quote(fs.Name))))
 		}
 	}
 	allErrs = append(allErrs, ValidateFlowSchemaStatus(&fs.Status, field.NewPath("status"))...)


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/78](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/78)

To fix the issue, we need to ensure that `fs.Name` is properly escaped or sanitized before being embedded in the string. Since the string is used in an error message, we can use `strconv.Quote` to safely escape any special characters, including single quotes. This method wraps the string in double quotes and escapes any internal quotes or backslashes, ensuring the string is safe for inclusion in the error message.

Changes will be made to the line where `fmt.Sprintf` is used to construct the error message.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
