### PR TITLE
Potential fix for code scanning alert no. 75: Potentially unsafe quoting

### DIFF
--- a/pkg/apis/admissionregistration/validation/validation.go
+++ b/pkg/apis/admissionregistration/validation/validation.go
@@ -96,7 +96,7 @@ func validateResources(resources []string, fldPath *field.Path) field.ErrorList 
 			allErrors = append(allErrors, field.Invalid(fldPath.Index(i), resSub, fmt.Sprintf("if '%s/*' is present, must not specify %s", res, resSub)))
 		}
 		if _, ok := subResourcesWithWildcardResource[sub]; ok {
-			allErrors = append(allErrors, field.Invalid(fldPath.Index(i), resSub, fmt.Sprintf("if '*/%s' is present, must not specify %s", sub, resSub)))
+			allErrors = append(allErrors, field.Invalid(fldPath.Index(i), resSub, fmt.Sprintf("if '*/%s' is present, must not specify %s", strconv.Quote(sub), resSub)))
 		}
 		if sub == "*" {
 			resourcesWithWildcardSubresoures[res] = struct{}{}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/75](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/75)

To fix the issue, we need to ensure that the `sub` variable is properly escaped before embedding it into the string. Since the context involves constructing an error message, we can use `strconv.Quote` to safely escape the value. This method wraps the string in double quotes and escapes any special characters, including single quotes, ensuring that the resulting string is safe for embedding.

The fix involves:
1. Importing the `strconv` package if not already imported.
2. Replacing the direct use of `sub` in `fmt.Sprintf` with `strconv.Quote(sub)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
