### PR TITLE
Potential fix for code scanning alert no. 164: Potentially unsafe quoting

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -114,8 +114,9 @@ func ValidateHasLabel(meta metav1.ObjectMeta, fldPath *field.Path, key, expected
 	allErrs := field.ErrorList{}
 	actualValue, found := meta.Labels[key]
 	if !found {
+		escapedValue := strings.ReplaceAll(expectedValue, "'", "\\'")
 		allErrs = append(allErrs, field.Required(fldPath.Child("labels").Key(key),
-			fmt.Sprintf("must be '%s'", expectedValue)))
+			fmt.Sprintf("must be '%s'", escapedValue)))
 		return allErrs
 	}
 	if actualValue != expectedValue {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/164](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/164)

To fix the issue, we need to ensure that any single quotes in `expectedValue` are properly escaped before embedding it into the single-quoted string in the `fmt.Sprintf` call on line 118. This can be achieved using `strings.ReplaceAll` to replace single quotes with escaped single quotes (`\'`). This approach is consistent with the escaping already applied on line 122.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
