### PR TITLE
Potential fix for code scanning alert no. 74: Potentially unsafe quoting

### DIFF
--- a/pkg/apis/admissionregistration/validation/validation.go
+++ b/pkg/apis/admissionregistration/validation/validation.go
@@ -93,7 +93,7 @@ func validateResources(resources []string, fldPath *field.Path) field.ErrorList 
 		}
 		res, sub := parts[0], parts[1]
 		if _, ok := resourcesWithWildcardSubresoures[res]; ok {
-			allErrors = append(allErrors, field.Invalid(fldPath.Index(i), resSub, fmt.Sprintf("if '%s/*' is present, must not specify %s", res, resSub)))
+			allErrors = append(allErrors, field.Invalid(fldPath.Index(i), resSub, fmt.Sprintf("if %s/* is present, must not specify %s", strconv.Quote(res), resSub)))
 		}
 		if _, ok := subResourcesWithWildcardResource[sub]; ok {
 			allErrors = append(allErrors, field.Invalid(fldPath.Index(i), resSub, fmt.Sprintf("if '*/%s' is present, must not specify %s", strconv.Quote(sub), resSub)))


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/74](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/74)

To fix the issue, we need to ensure that the value of `res` is properly escaped before embedding it in the string. Since the string is being constructed for error reporting, we can use `strconv.Quote` to escape the value of `res`. This function wraps the string in double quotes and escapes any special characters, including single quotes, ensuring that the resulting string is safe to use.

The fix involves replacing the direct use of `res` in the `fmt.Sprintf` call with `strconv.Quote(res)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
