### PR TITLE
Potential fix for code scanning alert no. 151: Incorrect conversion between integer types

### DIFF
--- a/test/integration/apiserver/discovery/service.go
+++ b/test/integration/apiserver/discovery/service.go
@@ -72,13 +72,13 @@ func (f *fakeService) Run(ctx context.Context) error {
 		panic(err)
 	}
 
-	serverPort, err := strconv.Atoi(serverURL.Port())
+	parsedPort, err := strconv.ParseInt(serverURL.Port(), 10, 32)
 	if err != nil {
 		// This should never occur
 		panic(err)
 	}
 
-	port := int32(serverPort)
+	port := int32(parsedPort)
 
 	// Install service into the cluster
 	service, err := f.client.CoreV1().Services("default").Apply(


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/151](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/151)

To fix the issue, we need to ensure that the parsed integer is within the valid range of `int32` before converting it. This can be achieved by:
1. Using `strconv.ParseInt` with a bit size of 32 to directly parse the string into a 32-bit integer, avoiding the need for a separate bounds check.
2. Alternatively, if `strconv.Atoi` is retained, adding explicit bounds checks for `int32` before the conversion.

The first approach is preferred as it simplifies the code and avoids redundant checks. The fix will replace the use of `strconv.Atoi` with `strconv.ParseInt` and handle any parsing errors appropriately.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
