### PR TITLE
Potential fix for code scanning alert no. 150: Incorrect conversion between integer types

### DIFF
--- a/test/instrumentation/decode_metric.go
+++ b/test/instrumentation/decode_metric.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"math"
 	"time"
 
 	"k8s.io/component-base/metrics"
@@ -759,6 +760,10 @@ func decodeBucketArguments(fc *ast.CallExpr) (float64, float64, int, error) {
 	thirdArg, err := strconv.ParseInt(strArgs[2], 10, 64)
 	if err != nil {
 		return 0, 0, 0, newDecodeErrorf(fc.Args[2], errBuckets)
+	}
+	// Check if thirdArg is within the range of the int type
+	if thirdArg < math.MinInt || thirdArg > math.MaxInt {
+		return 0, 0, 0, newDecodeErrorf(fc.Args[2], "value out of range for int type")
 	}
 
 	return firstArg, secondArg, int(thirdArg), nil


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/150](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/150)

To fix the issue, we need to ensure that the value of `thirdArg` is within the range of the `int` type before converting it. This can be achieved by adding bounds checks using the constants `math.MaxInt` and `math.MinInt` from the `math` package. If the value is out of bounds, the function should return an appropriate error.

The changes will be made in the `decodeBucketArguments` function in the file `test/instrumentation/decode_metric.go`. Specifically:
1. Add bounds checks for `thirdArg` after parsing it with `strconv.ParseInt`.
2. If `thirdArg` is out of bounds, return an error instead of performing the conversion.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
