### PR TITLE
Potential fix for code scanning alert no. 98: Insecure TLS configuration

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1163,23 +1163,11 @@ func InitializeTLS(kf *options.KubeletFlags, kc *kubeletconfiginternal.KubeletCo
 		return nil, err
 	}
 
-	// Filter out insecure cipher suites
-	insecureCiphers := cliflag.InsecureTLSCiphers()
-	filteredCipherSuites := make([]uint16, 0, len(tlsCipherSuites))
-	for _, cipher := range tlsCipherSuites {
-		isInsecure := false
-		for _, insecureCipher := range insecureCiphers {
-			if cipher == insecureCipher {
-				isInsecure = true
-				klog.InfoS("Excluding insecure cipher suite.", "cipher", cipher)
-				break
-			}
-		}
-		if !isInsecure {
-			filteredCipherSuites = append(filteredCipherSuites, cipher)
-		}
+	// Use only secure cipher suites
+	tlsCipherSuites, err := cliflag.TLSCipherSuites(kc.TLSCipherSuites)
+	if err != nil {
+		return nil, err
 	}
-	tlsCipherSuites = filteredCipherSuites
 
 	// Enforce minimum TLS version of 1.2
 	minTLSVersion, err := cliflag.TLSVersion(kc.TLSMinVersion)

--- a/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag.go
+++ b/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag.go
@@ -73,11 +73,8 @@ func PreferredTLSCipherNames() []string {
 }
 
 func allCiphers() map[string]uint16 {
-	acceptedCiphers := make(map[string]uint16, len(ciphers)+len(insecureCiphers))
+	acceptedCiphers := make(map[string]uint16, len(ciphers))
 	for k, v := range ciphers {
-		acceptedCiphers[k] = v
-	}
-	for k, v := range insecureCiphers {
 		acceptedCiphers[k] = v
 	}
 	return acceptedCiphers


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/98](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/98)

To fix the issue, we will ensure that insecure cipher suites are excluded at the source by modifying the `cliflag.TLSCipherSuites` function to only include secure cipher suites. This will prevent insecure cipher suites from being passed to the `tls.Config` object in the first place. Additionally, we will simplify the filtering logic in `cmd/kubelet/app/server.go` to avoid redundant checks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
