### PR TITLE
Potential fix for code scanning alert no. 149: Incorrect conversion between integer types

### DIFF
--- a/pkg/util/procfs/procfs_linux.go
+++ b/pkg/util/procfs/procfs_linux.go
@@ -153,6 +153,11 @@ func getPids(re *regexp.Regexp) []int {
 			// Check if the name of the executable is what we are looking for
 			if re.MatchString(exe[0]) {
 				// Grab the PID from the directory path
+				// Ensure the PID is within the valid range for int
+				if pid < 0 || pid > math.MaxInt32 {
+					klog.Warningf("Skipping PID %d as it is out of range", pid)
+					continue
+				}
 				pids = append(pids, pid)
 			}
 		}

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -367,6 +367,11 @@ func findContainerRuntimeServiceName() (string, error) {
 
 	containerRuntimePid := runtimePids[0]
 
+	// Ensure the PID is within the valid range for uint32
+	if containerRuntimePid < 0 || containerRuntimePid > math.MaxUint32 {
+		framework.Failf("PID %d is out of range for uint32", containerRuntimePid)
+	}
+
 	unitName, err := conn.GetUnitNameByPID(ctx, uint32(containerRuntimePid))
 	framework.ExpectNoError(err, "Failed to get container runtime unit name")
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/149](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/149)

To fix the issue, we need to ensure that the integer value being converted to `uint32` is within the valid range of `uint32`. This can be achieved by adding an explicit bounds check before the conversion. If the value is out of range, an error should be returned or the program should handle it gracefully.

1. Modify the `getPidsForProcess` function in `test/e2e_node/util.go` to validate the PID values returned by `procfs.PidOf` or `getPidFromPidFile`.
2. Add a bounds check in `findContainerRuntimeServiceName` before converting `containerRuntimePid` to `uint32`.
3. Use the `math` package to define the maximum value of `uint32` for the bounds check.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
