### PR TITLE
Potential fix for code scanning alert no. 148: Incorrect conversion between integer types

### DIFF
--- a/test/e2e/storage/drivers/csi-test/mock/service/controller.go
+++ b/test/e2e/storage/drivers/csi-test/mock/service/controller.go
@@ -813,6 +813,12 @@ func getAllSnapshots(s *service, req *csi.ListSnapshotsRequest) (*csi.ListSnapsh
 				"startingToken=%s: %v",
 				v, err)
 		}
+		if i > math.MaxInt32 {
+			return nil, status.Errorf(
+				codes.Aborted,
+				"startingToken=%s exceeds maximum value for int32",
+				v)
+		}
 		startingToken = int32(i)
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/148](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/148)

To fix the issue, we need to add an upper bound check before converting the parsed value from `uint32` to `int32`. Specifically:
1. After parsing the value using `strconv.ParseUint`, check if the parsed value exceeds `math.MaxInt32` (2,147,483,647).
2. If the value is out of bounds, return an appropriate error message.
3. Only perform the conversion to `int32` if the value is within the valid range.

This ensures that the conversion is safe and prevents unexpected behavior due to out-of-range values.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
