### PR TITLE
Potential fix for code scanning alert no. 145: Incorrect conversion between integer types

### DIFF
--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -23,6 +23,7 @@ import (
 	"math/rand"
 	"strings"
 	"time"
+	"math"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -1247,6 +1248,11 @@ func testProportionalScalingDeployment(ctx context.Context, f *framework.Framewo
 	// Checking state of first rollout's replicaset.
 	maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(deployment.Spec.Strategy.RollingUpdate.MaxUnavailable, int(*(deployment.Spec.Replicas)), false)
 	framework.ExpectNoError(err)
+
+	// Ensure maxUnavailable is within the range of int32.
+	if maxUnavailable > math.MaxInt32 || maxUnavailable < math.MinInt32 {
+		framework.Failf("maxUnavailable value %d is out of range for int32", maxUnavailable)
+	}
 
 	// First rollout's replicaset should have Deployment's (replicas - maxUnavailable) = 10 - 2 = 8 available replicas.
 	minAvailableReplicas := replicas - int32(maxUnavailable)


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/145](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/145)

To fix the issue, we need to ensure that the value of `maxUnavailable` is within the valid range for `int32` before performing the conversion. This can be achieved by adding explicit bounds checks using the constants `math.MaxInt32` and `math.MinInt32` from the `math` package. If the value is out of range, an error should be returned or handled appropriately.

The changes will be made in the file `test/e2e/apps/deployment.go` at the relevant lines where the conversion occurs. Additionally, the `math` package will be imported if it is not already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
