### PR TITLE
Potential fix for code scanning alert no. 144: Incorrect conversion between integer types

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/service_port.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/service_port.go
@@ -18,7 +18,7 @@ package util
 
 import (
 	"fmt"
-
+	"math"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -40,7 +40,11 @@ func LookupContainerPortNumberByServicePort(svc v1.Service, pod v1.Pod, port int
 				// targetPort is omitted, and the IntValue() would be zero
 				return svcportspec.Port, nil
 			}
-			return int32(svcportspec.TargetPort.IntValue()), nil
+			intValue := svcportspec.TargetPort.IntValue()
+			if intValue < math.MinInt32 || intValue > math.MaxInt32 {
+				return port, fmt.Errorf("TargetPort value %d is out of bounds for int32", intValue)
+			}
+			return int32(intValue), nil
 		}
 		return LookupContainerPortNumberByName(pod, svcportspec.TargetPort.String())
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/144](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/144)

To fix the issue, we need to ensure that the value returned by `svcportspec.TargetPort.IntValue()` is within the valid range for `int32` before performing the cast. This can be achieved by adding explicit bounds checks using constants from the `math` package (`math.MaxInt32` and `math.MinInt32`). If the value is out of bounds, an appropriate error should be returned.

The fix involves:
1. Adding bounds checks for the value returned by `IntValue()` in `LookupContainerPortNumberByServicePort`.
2. Returning an error if the value is out of bounds, or handling it gracefully (e.g., returning a default value).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
