### PR TITLE
Potential fix for code scanning alert no. 137: Incorrect conversion between integer types

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"math"
 	"strings"
 	"time"
 
@@ -198,6 +199,9 @@ func translateServicePortToTargetPort(ports []string, svc corev1.Service, pod co
 			if localPort == remotePort {
 				localPort = strconv.Itoa(portnum)
 			}
+		}
+		if portnum < math.MinInt32 || portnum > math.MaxInt32 {
+			return nil, fmt.Errorf("port number %d is out of range for int32", portnum)
 		}
 		containerPort, err := util.LookupContainerPortNumberByServicePort(svc, pod, int32(portnum))
 		if err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/137](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/137)

To fix the issue, we need to ensure that the value of `portnum` is within the valid range for `int32` before performing the conversion. This can be achieved by adding an explicit bounds check using the constants `math.MinInt32` and `math.MaxInt32` from the `math` package. If the value is out of range, the function should return an appropriate error.

The fix involves:
1. Importing the `math` package to access `math.MinInt32` and `math.MaxInt32`.
2. Adding a bounds check for `portnum` before converting it to `int32` on line 202.
3. Returning an error if the bounds check fails.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
