### PR TITLE
Potential fix for code scanning alert no. 136: Incorrect conversion between integer types

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
@@ -474,10 +474,11 @@ func (o *ExposeServiceOptions) createService() (*corev1.Service, error) {
 		portStringSlice := strings.Split(portString, ",")
 		servicePortName := o.PortName
 		for i, stillPortString := range portStringSlice {
-			port, err := strconv.Atoi(stillPortString)
+			parsedPort, err := strconv.ParseInt(stillPortString, 10, 32)
 			if err != nil {
 				return nil, err
 			}
+			port := int32(parsedPort)
 			name := servicePortName
 			// If we are going to assign multiple ports to a service, we need to
 			// generate a different name for each one.


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/136](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/136)

To fix the issue, we need to ensure that the parsed integer value is within the valid range for `int32` before converting it. This can be achieved by:
1. Using `strconv.ParseInt` instead of `strconv.Atoi` to parse the string directly into a 32-bit integer, specifying the bit size as 32.
2. Alternatively, adding explicit bounds checks for the `int32` range after parsing the string with `strconv.Atoi`.

The first approach is preferred because it simplifies the code and avoids the need for manual bounds checking. We will replace `strconv.Atoi` with `strconv.ParseInt` and specify a bit size of 32. The result will then be cast to `int32`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
