### PR TITLE
Potential fix for code scanning alert no. 143: Incorrect conversion between integer types

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/deployment/deployment.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/deployment/deployment.go
@@ -20,7 +20,8 @@ import (
 	"context"
 	"sort"
 	"strconv"
-
+	"fmt"
+	"math"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -253,5 +254,11 @@ func ResolveFenceposts(maxSurge, maxUnavailable *intstrutil.IntOrString, desired
 		unavailable = 1
 	}
 
+	if surge > math.MaxInt32 || surge < math.MinInt32 {
+		return 0, 0, fmt.Errorf("surge value %d is out of range for int32", surge)
+	}
+	if unavailable > math.MaxInt32 || unavailable < math.MinInt32 {
+		return 0, 0, fmt.Errorf("unavailable value %d is out of range for int32", unavailable)
+	}
 	return int32(surge), int32(unavailable), nil
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/143](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/143)

To address the issue, we need to ensure that the value of `unavailable` is within the valid range for `int32` before performing the conversion. This can be achieved by adding explicit bounds checks using the constants `math.MaxInt32` and `math.MinInt32`. If the value is out of range, we should handle it appropriately, such as returning an error or clamping the value to the valid range.

The fix involves:
1. Importing the `math` package to access `math.MaxInt32` and `math.MinInt32`.
2. Adding bounds checks for the `surge` and `unavailable` variables before converting them to `int32`.
3. Returning an error if the values are out of range, as this is the safest approach to prevent unexpected behavior.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
