### PR TITLE
Potential fix for code scanning alert no. 140: Incorrect conversion between integer types

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/service.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/service.go
@@ -18,6 +18,7 @@ package versioned
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -146,6 +147,10 @@ func generateService(genericParams map[string]interface{}) (runtime.Object, erro
 			port, err := strconv.Atoi(stillPortString)
 			if err != nil {
 				return nil, err
+			}
+			// Ensure the port value fits within the range of int32
+			if port < math.MinInt32 || port > math.MaxInt32 {
+				return nil, fmt.Errorf("port value %d is out of range for int32", port)
 			}
 			name := servicePortName
 			// If we are going to assign multiple ports to a service, we need to


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/140](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/140)

To fix the issue, we need to ensure that the value parsed from `strconv.Atoi` is within the valid range of `int32` before performing the conversion. This can be achieved by adding explicit bounds checks using the constants `math.MinInt32` and `math.MaxInt32` from the `math` package. If the value is out of bounds, an appropriate error should be returned.

The changes will be made in the loop starting at line 145, where the `port` variable is parsed and converted. Specifically:
1. Add bounds checks after parsing the integer with `strconv.Atoi`.
2. If the value is out of bounds, return an error indicating the issue.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
