### PR TITLE
Potential fix for code scanning alert no. 132: Incorrect conversion between integer types

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/gce_pd.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/gce_pd.go
@@ -285,11 +285,11 @@ func (g *gcePersistentDiskCSITranslator) TranslateCSIPVToInTree(pv *v1.Persisten
 		ReadOnly: csiSource.ReadOnly,
 	}
 	if partition, ok := csiSource.VolumeAttributes["partition"]; ok && partition != "" {
-		partInt, err := strconv.Atoi(partition)
+		partInt64, err := strconv.ParseInt(partition, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to convert partition %v to integer: %v", partition, err)
+			return nil, fmt.Errorf("Failed to convert partition %v to 32-bit integer: %v", partition, err)
 		}
-		gceSource.Partition = int32(partInt)
+		gceSource.Partition = int32(partInt64)
 	}
 
 	// translate CSI topology to In-tree topology for rollback compatibility


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/132](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/132)

To fix the issue, we need to ensure that the parsed integer value is within the valid range for `int32` before converting it. This can be achieved by:
1. Using the `strconv.ParseInt` function with a bit size of 32, which directly parses the string into a 32-bit integer. This approach avoids the need for additional bounds checking.
2. Alternatively, if `strconv.Atoi` is retained, explicitly checking that the parsed value is within the range of `int32` (using `math.MinInt32` and `math.MaxInt32`) before performing the conversion.

The first approach is preferred because it simplifies the code and directly enforces the bit size during parsing.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
