### PR TITLE
Potential fix for code scanning alert no. 129: Incorrect conversion between integer types

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/api_object_versioner.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/api_object_versioner.go
@@ -99,6 +99,11 @@ func (a APIObjectVersioner) ParseResourceVersion(resourceVersion string) (uint64
 			field.Invalid(field.NewPath("resourceVersion"), resourceVersion, err.Error()),
 		})
 	}
+	if version > math.MaxInt64 {
+		return 0, NewInvalidError(field.ErrorList{
+			field.Invalid(field.NewPath("resourceVersion"), resourceVersion, "value exceeds int64 range"),
+		})
+	}
 	return version, nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -956,7 +956,7 @@ func (s *store) Watch(ctx context.Context, key string, opts storage.ListOptions)
 	}
 	rev, err := s.versioner.ParseResourceVersion(opts.ResourceVersion)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse resource version: %w", err)
 	}
 	return s.watcher.Watch(s.watchContext(ctx), preparedKey, int64(rev), opts)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/129](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/129)

To fix the issue, we need to ensure that the `uint64` value returned by `ParseResourceVersion` is within the range of `int64` before performing the conversion. If the value exceeds `math.MaxInt64`, we should handle it appropriately (e.g., return an error or use a default value).

1. Modify the `ParseResourceVersion` function in `api_object_versioner.go` to include a bounds check for `math.MaxInt64` before returning the parsed value.
2. Update the `Watch` function in `store.go` to handle any errors returned by the modified `ParseResourceVersion` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
