### PR TITLE
Potential fix for code scanning alert no. 124: Incorrect conversion between integer types

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"math"
 
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
 )
@@ -478,6 +479,10 @@ func (v *Version) Info() *apimachineryversion.Info {
 
 func itoa(i uint) string {
 	if i == 0 {
+		return ""
+	}
+	// Ensure the value fits within the range of int
+	if i > uint(math.MaxInt) {
 		return ""
 	}
 	return strconv.Itoa(int(i))


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/124](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/124)

To fix the issue, we need to ensure that the conversion from `uint` to `int` in the `itoa` function is safe. This can be achieved by adding an upper bound check to ensure that the `uint` value does not exceed the maximum value of `int`. If the value is out of range, the function should handle it gracefully (e.g., by returning an empty string or a default value).

The changes will be made in the `itoa` function in the file `staging/src/k8s.io/apimachinery/pkg/util/version/version.go`. We will use the `math` package to determine the maximum value of `int` and perform the necessary bounds check.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
