### PR TITLE
Potential fix for code scanning alert no. 123: Incorrect conversion between integer types

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -548,6 +548,10 @@ func ParseWarningHeader(header string) (result WarningHeader, remainder string, 
 		return WarningHeader{}, "", errors.New("invalid warning header: code segment is not 3 digits between 100-299")
 	}
 	codeInt, _ := strconv.ParseInt(code, 10, 64)
+	// Ensure codeInt is within the valid range for int
+	if codeInt < 100 || codeInt > 299 {
+		return WarningHeader{}, "", errors.New("invalid warning header: code segment out of range")
+	}
 
 	// verify agent presence
 	if len(agent) == 0 {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/123](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/123)

To fix the issue, we will add an explicit bounds check before converting `codeInt` to the `int` type. Since the `codeMatcher` regex already ensures that `code` is a three-digit number between 100 and 299, we can safely check that `codeInt` falls within this range. If it does not, we will return an error.

This approach ensures that the conversion is safe and avoids any unexpected behavior due to out-of-range values.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
