### PR TITLE
Potential fix for code scanning alert no. 124: Incorrect conversion between integer types

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
@@ -482,7 +482,8 @@ func itoa(i uint) string {
 		return ""
 	}
 	// Ensure the value fits within the range of int
-	if i > uint(math.MaxInt) {
+	maxInt := uint(1<<(strconv.IntSize-1) - 1) // Dynamically calculate the maximum value of int
+	if i > maxInt {
 		return ""
 	}
 	return strconv.Itoa(int(i))


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/124](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/124)

To fix the issue, we need to ensure that the `itoa` function dynamically checks the size of `int` based on the architecture of the system. This can be achieved by using the `strconv.IntSize` constant, which provides the size of `int` in bits (e.g., 32 or 64). We will replace the hardcoded `math.MaxInt` with a dynamically calculated maximum value based on `strconv.IntSize`.

Specifically:
1. Replace the `if i > uint(math.MaxInt)` check with a calculation of the maximum value of `int` based on `strconv.IntSize`.
2. Ensure that the fix does not alter the existing functionality of the `itoa` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
