### PR TITLE
Potential fix for code scanning alert no. 121: Incorrect conversion between integer types

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -19,6 +19,7 @@ package rest
 import (
 	"bytes"
 	"context"
+	"math"
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
@@ -1538,11 +1539,13 @@ func isTextResponse(resp *http.Response) bool {
 }
 
 // retryAfterSeconds returns the value of the Retry-After header and true, or 0 and false if
-// the header was missing or not a valid number.
+// the header was missing, not a valid number, or out of the int32 range.
 func retryAfterSeconds(resp *http.Response) (int, bool) {
 	if h := resp.Header.Get("Retry-After"); len(h) > 0 {
 		if i, err := strconv.Atoi(h); err == nil {
-			return i, true
+			if i >= 0 && i <= math.MaxInt32 {
+				return i, true
+			}
 		}
 	}
 	return 0, false


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/121](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/121)

To fix the issue, we need to ensure that the value of `retryAfterSeconds` is within the valid range for an `int32` before performing the conversion. This can be achieved by adding bounds checks in the `retryAfterSeconds` function in `request.go`. Specifically:
1. Check that the parsed integer is non-negative and does not exceed `math.MaxInt32`.
2. If the value is out of bounds, return a default value (e.g., `0`) or handle the error appropriately.

Additionally, the `NewGenericServerResponse` function in `errors.go` does not need further changes because the bounds check will already be enforced at the source (`retryAfterSeconds`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
