### PR TITLE
Potential fix for code scanning alert no. 124: Incorrect conversion between integer types

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
@@ -481,10 +481,6 @@ func itoa(i uint) string {
 	if i == 0 {
 		return ""
 	}
-	// Ensure the value fits within the range of int
-	maxInt := uint(1<<(strconv.IntSize-1) - 1) // Dynamically calculate the maximum value of int
-	if i > maxInt {
-		return ""
-	}
-	return strconv.Itoa(int(i))
+	// Directly convert the uint value to a string
+	return strconv.FormatUint(uint64(i), 10)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/124](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/124)

To fix the issue, we need to ensure that the conversion from `uint` to `int` is safe and does not result in unexpected values. This can be achieved by:
1. Using `strconv.FormatUint` instead of `strconv.Itoa` to directly convert the `uint` value to a string without requiring an intermediate conversion to `int`.
2. Removing the unnecessary bounds check (`maxInt`) since `strconv.FormatUint` operates directly on `uint` values and does not depend on the architecture-dependent `int` type.

The changes will be made in the `itoa` function in the file `staging/src/k8s.io/apimachinery/pkg/util/version/version.go`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
