### PR TITLE
Potential fix for code scanning alert no. 117: Incorrect conversion between integer types

### DIFF
--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -259,10 +259,11 @@ func (plugin *iscsiPlugin) ConstructVolumeSpec(volumeName, mountPath string) (vo
 	if len(arr) < 2 {
 		return volume.ReconstructedVolume{}, fmt.Errorf("failed to retrieve lun from globalPDPath: %v", globalPDPath)
 	}
-	lun, err := strconv.Atoi(arr[1])
+	lun64, err := strconv.ParseInt(arr[1], 10, 32)
 	if err != nil {
 		return volume.ReconstructedVolume{}, err
 	}
+	lun := int32(lun64)
 	iface, _ := extractIface(globalPDPath)
 	iscsiVolume := &v1.Volume{
 		Name: volumeName,


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/117](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/117)

To fix the issue, we need to ensure that the value of `lun` is within the valid range for `int32` before performing the conversion. This can be achieved by:
1. Using `strconv.ParseInt` instead of `strconv.Atoi` to parse the string directly into a 32-bit integer, specifying the bit size as 32.
2. Alternatively, adding explicit bounds checks for the `int32` range (`math.MinInt32` to `math.MaxInt32`) after parsing the value with `strconv.Atoi`.

The first approach is preferred because it simplifies the code and avoids the need for manual bounds checking.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
