### PR TITLE
Potential fix for code scanning alert no. 119: Incorrect conversion between integer types

### DIFF
--- a/pkg/volume/util/fsquota/project.go
+++ b/pkg/volume/util/fsquota/project.go
@@ -132,7 +132,7 @@ func closeProjectFiles(fProjects *os.File, fProjid *os.File) error {
 
 func parseProject(l string) projectType {
 	if match := projectsParseRegexp.FindStringSubmatch(l); match != nil {
-		i, err := strconv.Atoi(match[1])
+		i, err := strconv.ParseInt(match[1], 10, 32)
 		if err == nil {
 			return projectType{true, common.QuotaID(i), match[2], l}
 		}
@@ -142,7 +142,7 @@ func parseProject(l string) projectType {
 
 func parseProjid(l string) projectType {
 	if match := projidParseRegexp.FindStringSubmatch(l); match != nil {
-		i, err := strconv.Atoi(match[2])
+		i, err := strconv.ParseInt(match[2], 10, 32)
 		if err == nil {
 			return projectType{true, common.QuotaID(i), match[1], l}
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/119](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/119)

To fix the issue, we need to ensure that the value parsed by `strconv.Atoi` is within the valid range for `common.QuotaID` before performing the conversion. This can be achieved by:
1. Replacing `strconv.Atoi` with `strconv.ParseInt`, specifying the bit size of `common.QuotaID` (e.g., 32 bits) to directly parse the value into a compatible type.
2. Alternatively, adding explicit bounds checks to ensure the parsed value is within the range of `common.QuotaID` before converting it.

The first approach is preferred because it simplifies the code and avoids the need for manual bounds checking.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
