### PR TITLE
Potential fix for code scanning alert no. 114: Incorrect conversion between integer types

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1941,6 +1941,11 @@ func (proxier *Proxier) syncEndpoint(svcPortName proxy.ServicePortName, onlyNode
 			proxier.logger.Error(err, "Failed to parse endpoint port", "port", port)
 			continue
 		}
+		// Check if portNum is within the valid range for uint16
+		if portNum < 0 || portNum > 65535 {
+			proxier.logger.Error(fmt.Errorf("port out of range"), "Endpoint port is out of range for uint16", "port", portNum)
+			continue
+		}
 
 		delDest := &utilipvs.RealServer{
 			Address: netutils.ParseIPSloppy(ip),


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/114](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/114)

To fix the issue, we need to ensure that the value of `portNum` is within the valid range for `uint16` (0 to 65535) before performing the conversion. If the value is out of bounds, we should handle the error appropriately (e.g., log an error and skip processing the endpoint). This can be achieved by adding a conditional check after parsing the port number with `strconv.Atoi`.

The changes will be made in the `syncEndpoint` function in `pkg/proxy/ipvs/proxier.go`:
1. Add a bounds check for `portNum` after parsing it with `strconv.Atoi`.
2. If `portNum` is out of bounds, log an error and skip further processing for that endpoint.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
