### PR TITLE
Potential fix for code scanning alert no. 109: Incorrect conversion between integer types

### DIFF
--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -817,6 +817,14 @@ func (dc *DisruptionController) getExpectedPodCount(ctx context.Context, pdb *po
 		if err != nil {
 			return
 		}
+		// Ensure maxUnavailable is within the bounds of int32
+		if maxUnavailable > math.MaxInt32 {
+			err = fmt.Errorf("maxUnavailable value %d exceeds int32 maximum", maxUnavailable)
+			return
+		} else if maxUnavailable < math.MinInt32 {
+			err = fmt.Errorf("maxUnavailable value %d is below int32 minimum", maxUnavailable)
+			return
+		}
 		desiredHealthy = expectedCount - int32(maxUnavailable)
 		if desiredHealthy < 0 {
 			desiredHealthy = 0


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/109](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/109)

To fix the issue, we need to ensure that the value of `maxUnavailable` is within the valid range for `int32` before performing the conversion. This can be achieved by adding an explicit bounds check against `math.MaxInt32` and `math.MinInt32` (if negative values are possible). If the value exceeds these bounds, an error should be returned or handled appropriately.

The changes will be made in the `getExpectedPodCount` function in `pkg/controller/disruption/disruption.go`. Specifically:
1. Add a bounds check for `maxUnavailable` before converting it to `int32`.
2. If the value is out of bounds, handle the error or adjust the value to fit within the valid range.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
