### PR TITLE
Potential fix for code scanning alert no. 113: Incorrect conversion between integer types

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1884,6 +1884,11 @@ func (proxier *Proxier) syncEndpoint(svcPortName proxy.ServicePortName, onlyNode
 			proxier.logger.Error(err, "Failed to parse endpoint port", "port", port)
 			continue
 		}
+		// Ensure portNum is within the valid range for uint16
+		if portNum < 0 || portNum > 65535 {
+			proxier.logger.Error(fmt.Errorf("port out of range"), "Port number out of range for uint16", "port", portNum)
+			continue
+		}
 
 		newDest := &utilipvs.RealServer{
 			Address: netutils.ParseIPSloppy(ip),


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/113](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/113)

To fix the issue, we need to ensure that the `portNum` value is within the valid range for `uint16` (0 to 65535) before performing the conversion. This can be achieved by adding an explicit bounds check after parsing the value with `strconv.Atoi`. If the value is out of range, we should log an error and skip processing the endpoint.

**Steps to fix:**
1. Add a bounds check for `portNum` after parsing it with `strconv.Atoi`.
2. Ensure that the value is within the range `[0, 65535]` before converting it to `uint16`.
3. If the value is out of range, log an error and continue to the next iteration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
