### PR TITLE
Potential fix for code scanning alert no. 108: Incorrect conversion between integer types

### DIFF
--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -902,6 +902,14 @@ func ResolveFenceposts(maxSurge, maxUnavailable *intstrutil.IntOrString, desired
 		unavailable = 1
 	}
 
+	// Ensure surge and unavailable are within the bounds of int32
+	if surge > math.MaxInt32 || surge < math.MinInt32 {
+		return 0, 0, fmt.Errorf("surge value %d is out of int32 bounds", surge)
+	}
+	if unavailable > math.MaxInt32 || unavailable < math.MinInt32 {
+		return 0, 0, fmt.Errorf("unavailable value %d is out of int32 bounds", unavailable)
+	}
+
 	return int32(surge), int32(unavailable), nil
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/108](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/108)

To fix the issue, we need to ensure that the conversion from `int` to `int32` in the `ResolveFenceposts` function is safe. This can be achieved by adding explicit bounds checks for the `surge` and `unavailable` values before converting them to `int32`. If the values exceed the range of `int32`, an error should be returned.

The fix involves:
1. Adding bounds checks for `surge` and `unavailable` against the `math.MaxInt32` and `math.MinInt32` constants.
2. Returning an error if the values are out of bounds, ensuring the function does not proceed with invalid data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
