### PR TITLE
Potential fix for code scanning alert no. 104: Incorrect conversion between integer types

### DIFF
--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -988,6 +988,9 @@ func parseIndexInterval(intervalStr string, completions int32) (int32, int32, er
 	if err != nil {
 		return 0, 0, fmt.Errorf("cannot convert string to integer for index: %q", limitsStr[0])
 	}
+	if x < math.MinInt32 || x > math.MaxInt32 {
+		return 0, 0, fmt.Errorf("index out of int32 range: %q", limitsStr[0])
+	}
 	if x >= int(completions) {
 		return 0, 0, fmt.Errorf("too large index: %q", limitsStr[0])
 	}
@@ -995,6 +998,9 @@ func parseIndexInterval(intervalStr string, completions int32) (int32, int32, er
 		y, err := strconv.Atoi(limitsStr[1])
 		if err != nil {
 			return 0, 0, fmt.Errorf("cannot convert string to integer for index: %q", limitsStr[1])
+		}
+		if y < math.MinInt32 || y > math.MaxInt32 {
+			return 0, 0, fmt.Errorf("index out of int32 range: %q", limitsStr[1])
 		}
 		if y >= int(completions) {
 			return 0, 0, fmt.Errorf("too large index: %q", limitsStr[1])


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/104](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/104)

To fix the issue, we need to ensure that the value of `x` is within the valid range for `int32` before converting it. This can be achieved by adding explicit bounds checks for `x` against `math.MinInt32` and `math.MaxInt32`. If `x` falls outside this range, the function should return an appropriate error.

Additionally, the same bounds check should be applied to `y` on line 1005, as it is also converted to `int32`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
