### PR TITLE
Potential fix for code scanning alert no. 101: Incorrect conversion between integer types

### DIFF
--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -984,24 +984,20 @@ func parseIndexInterval(intervalStr string, completions int32) (int32, int32, er
 	if len(limitsStr) > 2 {
 		return 0, 0, fmt.Errorf("the fragment %q violates the requirement that an index interval can have at most two parts separated by '-'", intervalStr)
 	}
-	x, err := strconv.Atoi(limitsStr[0])
+	x64, err := strconv.ParseInt(limitsStr[0], 10, 32)
 	if err != nil {
-		return 0, 0, fmt.Errorf("cannot convert string to integer for index: %q", limitsStr[0])
+		return 0, 0, fmt.Errorf("cannot parse string to int32 for index: %q", limitsStr[0])
 	}
-	if x < math.MinInt32 || x > math.MaxInt32 {
-		return 0, 0, fmt.Errorf("index out of int32 range: %q", limitsStr[0])
-	}
+	x := int32(x64)
 	if x >= int(completions) {
 		return 0, 0, fmt.Errorf("too large index: %q", limitsStr[0])
 	}
 	if len(limitsStr) > 1 {
-		y, err := strconv.Atoi(limitsStr[1])
+		y64, err := strconv.ParseInt(limitsStr[1], 10, 32)
 		if err != nil {
-			return 0, 0, fmt.Errorf("cannot convert string to integer for index: %q", limitsStr[1])
+			return 0, 0, fmt.Errorf("cannot parse string to int32 for index: %q", limitsStr[1])
 		}
-		if y < math.MinInt32 || y > math.MaxInt32 {
-			return 0, 0, fmt.Errorf("index out of int32 range: %q", limitsStr[1])
-		}
+		y := int32(y64)
 		if y >= int(completions) {
 			return 0, 0, fmt.Errorf("too large index: %q", limitsStr[1])
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/101](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/101)

To fix the issue, we should replace `strconv.Atoi` with `strconv.ParseInt`, specifying a bit size of 32. This ensures that the parsed value is already constrained to the range of `int32`, eliminating the need for additional bounds checks for `int32`. The conversion to `int32` will then be safe and consistent across architectures.

Changes to be made:
1. Replace `strconv.Atoi` with `strconv.ParseInt` for parsing `limitsStr[0]` and `limitsStr[1]`.
2. Update the error handling to accommodate the use of `strconv.ParseInt`.
3. Remove the explicit bounds checks for `math.MinInt32` and `math.MaxInt32` since `strconv.ParseInt` with a bit size of 32 inherently enforces these bounds.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
