### PR TITLE
Potential fix for code scanning alert no. 92: Uncontrolled data used in path expression

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -529,7 +529,13 @@ func (o *CopyOptions) untarAll(ns, pod string, prefix string, src remotePath, de
 		// with cleaning remote paths
 		destFileName := dest.Join(newRemotePath(header.Name[len(prefix):]))
 
-		if !isRelative(dest, destFileName) {
+		// Validate that destFileName is within the intended destination directory
+		absDest, err := filepath.Abs(dest.String())
+		if err != nil {
+			return fmt.Errorf("failed to resolve destination path: %v", err)
+		}
+		absDestFileName, err := filepath.Abs(destFileName.String())
+		if err != nil || !strings.HasPrefix(absDestFileName, absDest) {
 			fmt.Fprintf(o.IOStreams.ErrOut, "warning: file %q is outside target destination, skipping\n", destFileName)
 			continue
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/92](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/92)

To address the issue, we need to ensure that the `destFileName` is strictly validated before being used in file system operations. Specifically:
1. Normalize the path using `filepath.Abs` to resolve any `..` components.
2. Verify that the resulting path is within the intended destination directory (`dest`).
3. Reject any paths that fail these checks.

This approach ensures that even if the tar archive contains malicious paths, they cannot escape the intended destination directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
