### PR TITLE
Potential fix for code scanning alert no. 100: Incorrect conversion between integer types

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -542,7 +542,11 @@ func EtcdSupportedVersion(supportedEtcdVersion map[uint8]string, versionString s
 	if err != nil {
 		return nil, nil, err
 	}
-	desiredVersion, etcdStringVersion := uint8(kubernetesVersion.Minor()), ""
+	var desiredVersion uint8
+	if kubernetesVersion.Minor() > math.MaxUint8 {
+		return nil, nil, fmt.Errorf("minor version %d exceeds maximum value for uint8", kubernetesVersion.Minor())
+	}
+	desiredVersion, etcdStringVersion = uint8(kubernetesVersion.Minor()), ""
 
 	min, max := ^uint8(0), uint8(0)
 	for k, v := range supportedEtcdVersion {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/100](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/100)

To address the issue, we need to add an upper bound check before converting the `kubernetesVersion.Minor()` value to `uint8`. This ensures that the value fits within the range of `uint8` (0–255). If the value exceeds this range, we should handle it gracefully, such as by returning an error or using a fallback value.

**Steps to fix:**
1. Modify the `EtcdSupportedVersion` function in `cmd/kubeadm/app/constants/constants.go` to include a bounds check for the `kubernetesVersion.Minor()` value before converting it to `uint8`.
2. If the value is out of range, return an appropriate error or fallback behavior.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
