### PR TITLE
Potential fix for code scanning alert no. 92: Uncontrolled data used in path expression

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -541,7 +541,12 @@ func (o *CopyOptions) untarAll(ns, pod string, prefix string, src remotePath, de
 			continue
 		}
 
-		if err := os.MkdirAll(destFileName.Dir().String(), 0755); err != nil {
+		// Validate and sanitize the directory path before creating it
+		sanitizedDirPath := filepath.Clean(destFileName.Dir().String())
+		if !strings.HasPrefix(sanitizedDirPath, absDest) {
+			return fmt.Errorf("invalid directory path: %q is outside the target destination", sanitizedDirPath)
+		}
+		if err := os.MkdirAll(sanitizedDirPath, 0755); err != nil {
 			return err
 		}
 		if header.FileInfo().IsDir() {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/92](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/92)

To address the issue, we need to ensure that all paths derived from user-controlled data are validated and sanitized before being used in file or directory operations. Specifically:
1. Validate and sanitize `destFileName.Dir().String()` before passing it to `os.MkdirAll`.
2. Use `filepath.Clean` to normalize the path and ensure it does not escape the intended destination directory.
3. Add a check to confirm that the sanitized path is within the allowed destination directory (`absDest`).

This fix will ensure that the directory creation operation is safe and does not allow directory traversal or other path manipulation attacks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
