### PR TITLE
Potential fix for code scanning alert no. 90: Uncontrolled data used in path expression

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -436,7 +436,14 @@ func recursiveTar(srcDir, srcFile localPath, destDir, destFile remotePath, tw *t
 		return err
 	}
 	for _, fpath := range matchedPaths {
-		stat, err := os.Lstat(fpath)
+		absFpath, err := filepath.Abs(fpath)
+		if err != nil {
+			return err
+		}
+		if !strings.HasPrefix(absFpath, srcDir.String()) {
+			return fmt.Errorf("invalid file path: %s", fpath)
+		}
+		stat, err := os.Lstat(absFpath)
 		if err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/filespec.go
@@ -61,7 +61,12 @@ func (p localPath) Clean() localPath {
 }
 
 func (p localPath) Join(elem pathSpec) localPath {
-	return newLocalPath(filepath.Join(p.file, elem.String()))
+	joinedPath := filepath.Join(p.file, elem.String())
+	cleanPath := filepath.Clean(joinedPath)
+	if strings.Contains(cleanPath, "..") {
+		return newLocalPath("") // Return an empty path to indicate invalid input
+	}
+	return newLocalPath(cleanPath)
 }
 
 func (p localPath) Glob() (matches []string, err error) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/90](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/90)

To address the issue, we need to validate and sanitize the user-controlled input before it is used in file operations. Specifically:
1. Ensure that the resolved paths are within a safe directory to prevent path traversal attacks.
2. Use `filepath.Abs` to resolve the absolute path and verify that it starts with a predefined safe directory.
3. Reject any input that contains invalid or unexpected components, such as `..` or path separators.

The fix will involve modifying the `recursiveTar` function to validate `fpath` before it is used. Additionally, we will ensure that the `srcDir` and `srcFile` inputs are sanitized when they are joined.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
