### PR TITLE
Potential fix for code scanning alert no. 72: Disabled TLS certificate check

### DIFF
--- a/staging/src/k8s.io/client-go/util/cert/server_inspection.go
+++ b/staging/src/k8s.io/client-go/util/cert/server_inspection.go
@@ -29,8 +29,12 @@ import (
 func GetClientCANames(apiHost string) ([]string, error) {
 	// when we run this the second time, we know which one we are expecting
 	acceptableCAs := []string{}
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil || rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: true, // this is insecure to always get to the GetClientCertificate
+		RootCAs: rootCAs,
 		GetClientCertificate: func(hello *tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			acceptableCAs = []string{}
 			for _, curr := range hello.AcceptableCAs {
@@ -63,8 +67,12 @@ func GetClientCANamesForURL(kubeConfigURL string) ([]string, error) {
 // GetServingCertificates returns the x509 certs used by a server as certificates and pem encoded bytes.
 // The serverName is optional for specifying a different name to get SNI certificates.  apiHost is "host:port"
 func GetServingCertificates(apiHost, serverName string) ([]*x509.Certificate, [][]byte, error) {
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil || rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: true, // this is insecure so that we always get connected
+		RootCAs: rootCAs,
 	}
 	// if a name is specified for SNI, set it.
 	if len(serverName) > 0 {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/72](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/72)

To fix the issue, we need to ensure that TLS certificate verification is enabled. This involves removing `InsecureSkipVerify: true` and properly configuring the `tls.Config` object to validate server certificates. If the intent is to allow this behavior only in specific scenarios (e.g., debugging), we should make it explicit by adding a parameter or configuration flag to control this behavior. For production use, the default should always enforce certificate validation.

In this case, we will:
1. Remove `InsecureSkipVerify: true` from the `tls.Config` object.
2. Add a mechanism to load and use a trusted certificate pool (`x509.CertPool`) for server certificate validation.
3. Ensure that the code fails securely if no trusted certificates are provided.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
