### PR TITLE
Potential fix for code scanning alert no. 82: Uncontrolled data used in path expression

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/disk/cached_discovery.go
@@ -68,6 +68,10 @@ var _ discovery.CachedDiscoveryInterface = &CachedDiscoveryClient{}
 
 // ServerResourcesForGroupVersion returns the supported resources for a group and version.
 func (d *CachedDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	// Validate groupVersion to ensure it does not contain invalid characters
+	if strings.Contains(groupVersion, "/") || strings.Contains(groupVersion, "\\") || strings.Contains(groupVersion, "..") {
+		return nil, fmt.Errorf("invalid groupVersion: %s", groupVersion)
+	}
 	filename := filepath.Join(d.cacheDirectory, groupVersion, "serverresources.json")
 	cachedBytes, err := d.getCachedFile(filename)
 	// don't fail on errors, we either don't have a file or won't be able to run the cached check. Either way we can fallback.


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/82](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/82)

To fix the issue, we need to validate and sanitize the `groupVersion` input before using it to construct the `filename`. Specifically:
1. Ensure that `groupVersion` does not contain any path traversal sequences (`..`) or path separators (`/` or `\`).
2. Use a whitelist or regex to allow only valid `groupVersion` values if possible.
3. Alternatively, resolve the constructed path to an absolute path and verify that it is within the intended `cacheDirectory`.

The best approach is to validate `groupVersion` as a single path component (e.g., using `strings.Contains` to check for invalid characters) before constructing the `filename`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
