### PR TITLE
Potential fix for code scanning alert no. 67: Disabled TLS certificate check

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -19,6 +19,7 @@ package apiclient
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"net"
@@ -263,8 +264,13 @@ func (w *KubeWaiter) WaitForControlPlaneComponents(podMap map[string]*v1.Pod, ap
 		fmt.Printf("[control-plane-check] Checking %s at %s\n", comp.name, comp.url)
 
 		go func(comp controlPlaneComponent) {
+			// Create a secure TLS configuration with a trusted certificate pool
+			rootCAs, err := x509.SystemCertPool()
+			if err != nil || rootCAs == nil {
+				rootCAs = x509.NewCertPool()
+			}
 			tr := &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				TLSClientConfig: &tls.Config{RootCAs: rootCAs},
 			}
 			client := &http.Client{Transport: tr}
 			start := time.Now()


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/67](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/67)

To fix the issue, we need to ensure that TLS certificate verification is enabled. This involves removing the `InsecureSkipVerify: true` configuration and properly configuring the `tls.Config` object to trust the appropriate certificates. This can be achieved by either using the system's default certificate pool or providing a custom certificate pool that includes the necessary trusted certificates.

The fix will involve:
1. Removing `InsecureSkipVerify: true` from the `tls.Config`.
2. Configuring the `tls.Config` to use a trusted certificate pool, which can be loaded from the system or specified explicitly.
3. Ensuring that the HTTP client uses this secure configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
