### PR TITLE
Potential fix for code scanning alert no. 70: Disabled TLS certificate check

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/dial.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/dial.go
@@ -67,8 +67,12 @@ func DialURL(ctx context.Context, url *url.URL, transport http.RoundTripper) (ne
 				// tls.Client requires non-nil config
 				klog.Warning("using custom dialer with no TLSClientConfig. Defaulting to InsecureSkipVerify")
 				// tls.Handshake() requires ServerName or InsecureSkipVerify
+				inferredHost := dialAddr
+				if host, _, err := net.SplitHostPort(dialAddr); err == nil {
+					inferredHost = host
+				}
 				tlsConfig = &tls.Config{
-					InsecureSkipVerify: true,
+					ServerName: inferredHost,
 				}
 			} else if len(tlsConfig.ServerName) == 0 && !tlsConfig.InsecureSkipVerify {
 				// tls.HandshakeContext() requires ServerName or InsecureSkipVerify


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/70](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/70)

To fix the issue, we need to ensure that `InsecureSkipVerify` is not set to `true`. Instead, we should configure the `tls.Config` object properly to include a valid `ServerName` or other necessary parameters to enable secure TLS communication. If no `TLSClientConfig` is provided, we should infer the `ServerName` from the hostname and create a secure `tls.Config` object without disabling certificate verification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
