### PR TITLE
Potential fix for code scanning alert no. 71: Disabled TLS certificate check

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
@@ -318,8 +318,10 @@ func backends(storageConfig storagebackend.Config, grOverrides map[schema.GroupR
 		servers.Insert(overrides.etcdLocation...)
 	}
 
-	tlsConfig := &tls.Config{
-		InsecureSkipVerify: true,
+	tlsConfig := &tls.Config{}
+	if len(storageConfig.Transport.TrustedCAFile) == 0 {
+		klog.Errorf("no trusted CA file provided; cannot create secure backends")
+		return nil
 	}
 	if len(storageConfig.Transport.CertFile) > 0 && len(storageConfig.Transport.KeyFile) > 0 {
 		cert, err := tls.LoadX509KeyPair(storageConfig.Transport.CertFile, storageConfig.Transport.KeyFile)


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/71](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/71)

To fix the issue, we will ensure that `InsecureSkipVerify` is never set to `true` in production code. Instead, we will enforce proper certificate verification by requiring a trusted CA file or other valid certificate configuration. If no trusted CA file is provided, the function should log an error and avoid creating insecure backends.

The changes will:
1. Remove the default `InsecureSkipVerify: true` setting.
2. Add a check to ensure that a trusted CA file or valid certificate configuration is provided. If not, log an error and skip creating insecure backends.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
