### PR TITLE
Potential fix for code scanning alert no. 69: Disabled TLS certificate check

### DIFF
--- a/pkg/probe/http/http.go
+++ b/pkg/probe/http/http.go
@@ -38,7 +38,7 @@ const (
 // followNonLocalRedirects configures whether the prober should follow redirects to a different hostname.
 // If disabled, redirects to other hosts will trigger a warning result.
 func New(followNonLocalRedirects bool) Prober {
-	tlsConfig := &tls.Config{InsecureSkipVerify: true}
+	tlsConfig := &tls.Config{}
 	return NewWithTLSConfig(tlsConfig, followNonLocalRedirects)
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/69](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/69)

To fix the issue, we should avoid setting `InsecureSkipVerify` to `true`. Instead, we should configure the `tls.Config` object with proper certificate verification. This involves ensuring that the application uses a valid certificate authority (CA) bundle to verify server certificates. If the intention is to allow custom certificates, we can provide a mechanism to load trusted certificates dynamically.

The changes will involve:
1. Removing `InsecureSkipVerify: true` from the `tls.Config` initialization in the `New` function.
2. Adding a mechanism to load trusted certificates (if necessary) or using the system's default CA pool.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
