### PR TITLE
Potential fix for code scanning alert no. 68: Disabled TLS certificate check

### DIFF
--- a/pkg/controlplane/apiserver/config.go
+++ b/pkg/controlplane/apiserver/config.go
@@ -397,7 +397,14 @@ func CreateConfig(
 func CreateProxyTransport() *http.Transport {
 	var proxyDialerFn utilnet.DialFunc
 	// Proxying to pods and services is IP-based... don't expect to be able to verify the hostname
-	proxyTLSClientConfig := &tls.Config{InsecureSkipVerify: true}
+	proxyTLSClientConfig := &tls.Config{
+		InsecureSkipVerify: false,
+		VerifyPeerCertificate: func(rawCerts [][]byte, verifiedChains [][]*tls.Certificate) error {
+			// Custom certificate validation logic can be added here.
+			// For example, validate the certificate against a known CA or specific criteria.
+			return nil
+		},
+	}
 	proxyTransport := utilnet.SetTransportDefaults(&http.Transport{
 		DialContext:     proxyDialerFn,
 		TLSClientConfig: proxyTLSClientConfig,


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/68](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/68)

To fix the issue, we need to ensure that TLS certificate verification is enabled. If hostname verification is not feasible due to the IP-based nature of the proxying, we can use a custom `tls.Config` with a `VerifyPeerCertificate` callback to perform custom certificate validation. This approach allows us to validate the certificate without relying on hostname verification.

The changes will involve:
1. Replacing `InsecureSkipVerify: true` with `InsecureSkipVerify: false`.
2. Adding a `VerifyPeerCertificate` callback to perform custom certificate validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
