### PR TITLE
Potential fix for code scanning alert no. 65: Clear-text logging of sensitive information

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server.go
+++ b/staging/src/k8s.io/kubectl/pkg/proxy/proxy_server.go
@@ -144,8 +144,9 @@ type Server struct {
 type responder struct{}
 
 func (r *responder) Error(w http.ResponseWriter, req *http.Request, err error) {
-	klog.Errorf("Error while proxying request: %v", err)
-	http.Error(w, err.Error(), http.StatusInternalServerError)
+	sanitizedErr := fmt.Errorf("an error occurred while processing the request")
+	klog.Errorf("Error while proxying request: %v", sanitizedErr)
+	http.Error(w, sanitizedErr.Error(), http.StatusInternalServerError)
 }
 
 // makeUpgradeTransport creates a transport that explicitly bypasses HTTP2 support


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/65](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/65)

To address the issue, we will sanitize the error message before logging it. Specifically, we will ensure that sensitive data is not included in the logged error message. This can be achieved by replacing the raw error message with a generic or sanitized version. Additionally, we will avoid logging the full error message if it contains sensitive data from HTTP headers.

The fix involves modifying the `Error` method in the `responder` struct to sanitize the error message before passing it to `klog.Errorf`. We will also ensure that the HTTP response sent to the client does not expose sensitive information.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
