### PR TITLE
Potential fix for code scanning alert no. 63: Clear-text logging of sensitive information

### DIFF
--- a/staging/src/k8s.io/cloud-provider/app/controllermanager.go
+++ b/staging/src/k8s.io/cloud-provider/app/controllermanager.go
@@ -64,6 +64,15 @@ import (
 	"k8s.io/klog/v2"
 )
 
+// sanitizeWebhooks removes or obfuscates sensitive information from the webhooks map before logging.
+func sanitizeWebhooks(webhooks map[string]WebhookHandler) map[string]string {
+	sanitized := make(map[string]string)
+	for key := range webhooks {
+		sanitized[key] = "handler_registered" // Replace actual handler details with a placeholder.
+	}
+	return sanitized
+}
+
 func init() {
 	utilruntime.Must(features.AddFeatureGates(utilfeature.DefaultMutableFeatureGate))
 	utilruntime.Must(logsapi.AddFeatureGates(utilfeature.DefaultMutableFeatureGate))
@@ -181,7 +190,7 @@ func Run(c *cloudcontrollerconfig.CompletedConfig, cloud cloudprovider.Interface
 
 	if utilfeature.DefaultFeatureGate.Enabled(cmfeatures.CloudControllerManagerWebhook) {
 		if len(webhooks) > 0 {
-			klog.Info("Webhook Handlers enabled: ", webhooks)
+			klog.Info("Webhook Handlers enabled: ", sanitizeWebhooks(webhooks))
 			handler := newHandler(webhooks)
 			if _, _, err := c.WebhookSecureServing.Serve(handler, 0, stopCh); err != nil {
 				return err


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/63](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/63)

To address the issue, the logging of the `webhooks` variable should be modified to avoid exposing sensitive information. Instead of logging the entire `webhooks` object, we can log only non-sensitive metadata or a sanitized version of the data. If the `webhooks` object contains sensitive fields, these fields should be excluded or obfuscated before logging.

The fix involves:
1. Identifying the structure of the `webhooks` object and determining which fields are sensitive.
2. Modifying the logging statement to exclude or obfuscate sensitive fields.
3. Ensuring that the fix does not alter the functionality of the application.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
