### PR TITLE
Potential fix for code scanning alert no. 60: Clear-text logging of sensitive information

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
@@ -337,7 +337,7 @@ func (o *AuditOptions) ApplyTo(
 	c.AuditBackend = appendBackend(logBackend, dynamicBackend)
 
 	if c.AuditBackend != nil {
-		klog.V(2).Infof("Using audit backend: %s", c.AuditBackend)
+		klog.V(2).Infof("Using audit backend: %T", c.AuditBackend)
 	}
 	return nil
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/60](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/60)

To address the issue, we need to ensure that sensitive data is not logged in clear text. The best approach is to sanitize or obfuscate the `AuditBackend` object before logging it. Specifically, we should avoid including sensitive fields like `password` in the log output. This can be achieved by overriding the `String()` method of the relevant objects (e.g., `basicAuthRoundTripper` or `AuditBackend`) to exclude sensitive data or by explicitly sanitizing the data before logging.

In this case, we will modify the logging statement in `audit.go` to ensure that sensitive data is not included. Instead of logging the entire `AuditBackend` object, we will log a sanitized or high-level description of it.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
