### PR TITLE
Potential fix for code scanning alert no. 59: Clear-text logging of sensitive information

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
@@ -42,7 +42,7 @@ func WithImpersonation(handler http.Handler, a authorizer.Authorizer, s runtime.
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		impersonationRequests, err := buildImpersonationRequests(req.Header)
 		if err != nil {
-			klog.V(4).Infof("%v", err)
+			klog.V(4).Info("Error processing impersonation requests")
 			responsewriters.InternalError(w, req, err)
 			return
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/59](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/59)

To fix the issue, we should avoid logging sensitive information derived from HTTP headers. Instead of logging the entire error message, we can log a generic error message that does not include sensitive data. If detailed error information is needed for debugging, it can be handled securely (e.g., written to a secure location accessible only to authorized personnel).

Specifically:
1. Replace the logging statement on line 45 to avoid including the `err` variable directly.
2. Log a generic message such as "Error processing impersonation requests" without exposing sensitive details.
3. Ensure that sensitive data is not inadvertently logged elsewhere in the function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
