### PR TITLE
Potential fix for code scanning alert no. 58: Clear-text logging of sensitive information

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -449,7 +449,16 @@ func (h *UpgradeAwareHandler) tryUpgrade(w http.ResponseWriter, req *http.Reques
 	case <-writerComplete:
 	case <-readerComplete:
 	}
-	klog.V(6).Infof("Disconnecting from backend proxy %s\n  Headers: %v", &location, clone.Header)
+	// Filter or mask sensitive headers before logging
+	safeHeaders := http.Header{}
+	for key, values := range clone.Header {
+		if strings.EqualFold(key, "Authorization") || strings.EqualFold(key, "Cookie") {
+			safeHeaders[key] = []string{"***"} // Mask sensitive headers
+		} else {
+			safeHeaders[key] = values
+		}
+	}
+	klog.V(6).Infof("Disconnecting from backend proxy %s\n  Headers: %v", &location, safeHeaders)
 
 	return true
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/58](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/58)

To fix the issue, we should avoid logging sensitive information in the HTTP headers. Instead of logging the entire `clone.Header`, we can:
1. Log only non-sensitive headers (e.g., headers that are safe for debugging purposes).
2. Mask or obfuscate sensitive headers (e.g., replace their values with a placeholder like `***`).
3. Avoid logging headers entirely if they are not necessary for debugging.

The best approach here is to filter out sensitive headers and log only the safe ones. This can be achieved by iterating over the headers and excluding or masking sensitive ones before logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
