### PR TITLE
Potential fix for code scanning alert no. 51: Clear-text logging of sensitive information

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
@@ -19,6 +19,7 @@ package testing
 import (
 	"context"
 	"errors"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -239,6 +240,7 @@ func StartTestServer(t Logger, _ *TestServerInstanceOptions, customFlags []strin
 	return result, nil
 }
 
+
 // StartTestServerOrDie calls StartTestServer t.Fatal if it does not succeed.
 func StartTestServerOrDie(t Logger, instanceOptions *TestServerInstanceOptions, flags []string, storageConfig *storagebackend.Config) *TestServer {
 	result, err := StartTestServer(t, instanceOptions, flags, storageConfig)
@@ -246,7 +248,7 @@ func StartTestServerOrDie(t Logger, instanceOptions *TestServerInstanceOptions, 
 		return &result
 	}
 
-	t.Fatalf("failed to launch server: %v", err)
+	t.Fatalf("failed to launch server: %v", sanitizeError(err))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/resourceconfig/helpers.go
@@ -199,7 +199,7 @@ func getRuntimeConfigValue(overrides cliflag.ConfigurationMap, apiKey string, de
 		}
 		boolValue, err := strconv.ParseBool(flagValue)
 		if err != nil {
-			return false, fmt.Errorf("invalid value of %s: %s, err: %v", apiKey, flagValue, err)
+			return false, fmt.Errorf("invalid value for runtime configuration key, err: %v", err)
 		}
 		return boolValue, nil
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/51](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/51)

To fix the issue, we need to ensure that sensitive information, such as `apiKey`, is not logged in clear text. Instead of logging the full error message, we can sanitize it by removing or obfuscating sensitive details before logging. Specifically:
1. Modify the error message in `getRuntimeConfigValue` to exclude sensitive data like `apiKey`.
2. Ensure that any error derived from this function does not expose sensitive information when logged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
