### PR TITLE
Potential fix for code scanning alert no. 48: Clear-text logging of sensitive information

### DIFF
--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/kubernetes/third_party/forked/gonum/graph/traverse"
 )
 
+
 // NodeAuthorizer authorizes requests from kubelets, with the following logic:
 //  1. If a request is not from a node (NodeIdentity() returns isNode=false), reject
 //  2. If a specific node cannot be identified (NodeIdentity() returns nodeName=""), reject
@@ -374,10 +375,10 @@ func (r *NodeAuthorizer) authorizeNode(nodeName string, attrs authorizer.Attribu
 			case nodeName:
 				return authorizer.DecisionAllow, "", nil
 			case "":
-				klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+				klog.V(2).Infof("NODE DENY: '%s' %s", nodeName, sanitizeAttributes(attrs))
 				return authorizer.DecisionNoOpinion, fmt.Sprintf("node '%s' cannot read all nodes, only its own Node object", nodeName), nil
 			default:
-				klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+				klog.V(2).Infof("NODE DENY: '%s' %s", nodeName, sanitizeAttributes(attrs))
 				return authorizer.DecisionNoOpinion, fmt.Sprintf("node '%s' cannot read '%s', only its own Node object", nodeName, attrs.GetName()), nil
 			}
 		}
@@ -389,7 +390,7 @@ func (r *NodeAuthorizer) authorizeNode(nodeName string, attrs authorizer.Attribu
 		}
 	}
 
-	klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+	klog.V(2).Infof("NODE DENY: '%s' %s", nodeName, sanitizeAttributes(attrs))
 	return authorizer.DecisionNoOpinion, "", nil
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/48](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/48)

To fix the issue, we should avoid logging the entire `attrs` object directly. Instead, we can log only non-sensitive information or obfuscate sensitive fields. For example, we can extract and log only the necessary attributes (e.g., resource type, verb) while omitting or masking sensitive data. This ensures that the logs remain useful for debugging without exposing sensitive information.

The changes will involve:
1. Modifying the logging calls in `plugin/pkg/auth/authorizer/node/node_authorizer.go` to exclude sensitive data from `attrs`.
2. Introducing a helper function to sanitize or format the `attrs` object for safe logging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
