### PR TITLE
Potential fix for code scanning alert no. 170: Clear-text logging of sensitive information

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -449,12 +449,15 @@ func (h *UpgradeAwareHandler) tryUpgrade(w http.ResponseWriter, req *http.Reques
 	case <-writerComplete:
 	case <-readerComplete:
 	}
-	// Filter or mask sensitive headers before logging
+	// Log only safe headers to avoid exposing sensitive information
 	safeHeaders := http.Header{}
+	allowedHeaders := map[string]bool{
+		"Content-Type": true,
+		"User-Agent":   true,
+		"Accept":       true,
+	}
 	for key, values := range clone.Header {
-		if strings.EqualFold(key, "Authorization") || strings.EqualFold(key, "Cookie") {
-			safeHeaders[key] = []string{"***"} // Mask sensitive headers
-		} else {
+		if allowedHeaders[key] {
 			safeHeaders[key] = values
 		}
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/170](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/170)

To fix the issue, we will enhance the masking logic to ensure that all headers are either explicitly masked or omitted from the logs. Instead of selectively masking specific headers, we will log only a predefined set of safe headers (e.g., headers that are known to not contain sensitive information). This approach minimizes the risk of inadvertently logging sensitive data.

The changes involve:
1. Defining a list of safe headers that can be logged.
2. Filtering the headers to include only those in the safe list before logging.
3. Updating the logging statement to use the filtered headers.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
