### PR TITLE
Potential fix for code scanning alert no. 44: Clear-text logging of sensitive information

### DIFF
--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -41,6 +41,7 @@ import (
 )
 
 
+
 // NodeAuthorizer authorizes requests from kubelets, with the following logic:
 //  1. If a request is not from a node (NodeIdentity() returns isNode=false), reject
 //  2. If a specific node cannot be identified (NodeIdentity() returns nodeName=""), reject
@@ -344,7 +345,7 @@ func (r *NodeAuthorizer) authorizeResourceSlice(nodeName string, attrs authorize
 				}
 			}
 			// deny otherwise
-			klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+			klog.V(2).Infof("NODE DENY: '%s' %s", nodeName, sanitizeAttributes(attrs))
 			return authorizer.DecisionNoOpinion, "can only list/watch/deletecollection resourceslices with nodeName field selector", nil
 		} else {
 			// Allow broad list/watch access if AuthorizeNodeWithSelectors is not enabled.


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/44](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/44)

To fix the issue, we will sanitize the logging of the `attrs` object to ensure that sensitive information is not exposed. Instead of logging the entire `attrs` object, we will log only non-sensitive fields or a sanitized version of the object. This can be achieved by implementing a function to extract and log only the necessary, non-sensitive details from `attrs`. Additionally, we will avoid logging the raw `attrs` object directly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
