### PR TITLE
Potential fix for code scanning alert no. 40: Clear-text logging of sensitive information

### DIFF
--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -295,12 +295,14 @@ func (r *NodeAuthorizer) authorizeCSINode(nodeName string, attrs authorizer.Attr
 	case "get", "create", "update", "patch", "delete":
 		//ok
 	default:
-		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' (verb=%q, resource=%q, subresource=%q, name=%q, namespace=%q)", 
+			nodeName, attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource(), attrs.GetName(), attrs.GetNamespace())
 		return authorizer.DecisionNoOpinion, "can only get, create, update, patch, or delete a CSINode", nil
 	}
 
 	if len(attrs.GetSubresource()) > 0 {
-		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' (verb=%q, resource=%q, subresource=%q, name=%q, namespace=%q)", 
+			nodeName, attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource(), attrs.GetName(), attrs.GetNamespace())
 		return authorizer.DecisionNoOpinion, "cannot authorize CSINode subresources", nil
 	}
 
@@ -308,7 +310,8 @@ func (r *NodeAuthorizer) authorizeCSINode(nodeName string, attrs authorizer.Attr
 	// note we skip this check for create, since the authorizer doesn't know the name on create
 	// the noderestriction admission plugin is capable of performing this check at create time
 	if verb != "create" && attrs.GetName() != nodeName {
-		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' (verb=%q, resource=%q, subresource=%q, name=%q, namespace=%q)", 
+			nodeName, attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource(), attrs.GetName(), attrs.GetNamespace())
 		return authorizer.DecisionNoOpinion, "can only access CSINode with the same name as the requesting node", nil
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/40](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/40)

To fix the issue, we should avoid logging the entire `attrs` object directly, as it may contain sensitive information. Instead, we can log only the specific fields that are necessary for debugging and are confirmed to be non-sensitive. If detailed logging of `attrs` is required, we should sanitize or obfuscate sensitive fields before logging. 

In this case, we will replace the logging calls in the `authorizeCSINode` function to exclude sensitive data from `attrs`. We will log only the `nodeName` and a sanitized summary of `attrs` (e.g., its verb and resource name).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
