### PR TITLE
Potential fix for code scanning alert no. 32: Clear-text logging of sensitive information

### DIFF
--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -183,11 +183,11 @@ func (r *NodeAuthorizer) authorizeStatusUpdate(nodeName string, startingType ver
 // authorizeGet authorizes "get" requests to objects of the specified type if they are related to the specified node
 func (r *NodeAuthorizer) authorizeGet(nodeName string, startingType vertexType, attrs authorizer.Attributes) (authorizer.Decision, string, error) {
 	if attrs.GetVerb() != "get" {
-		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' (attributes redacted)", nodeName)
 		return authorizer.DecisionNoOpinion, "can only get individual resources of this type", nil
 	}
 	if len(attrs.GetSubresource()) > 0 {
-		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' (attributes redacted)", nodeName)
 		return authorizer.DecisionNoOpinion, "cannot get subresource", nil
 	}
 	return r.authorize(nodeName, startingType, attrs)
@@ -209,7 +209,7 @@ func (r *NodeAuthorizer) authorizeReadNamespacedObject(nodeName string, starting
 		return authorizer.DecisionNoOpinion, "cannot read subresource", nil
 	}
 	if len(attrs.GetNamespace()) == 0 {
-		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' (attributes redacted)", nodeName)
 		return authorizer.DecisionNoOpinion, "can only read namespaced object of this type", nil
 	}
 	return r.authorize(nodeName, startingType, attrs)
@@ -217,7 +217,7 @@ func (r *NodeAuthorizer) authorizeReadNamespacedObject(nodeName string, starting
 
 func (r *NodeAuthorizer) authorize(nodeName string, startingType vertexType, attrs authorizer.Attributes) (authorizer.Decision, string, error) {
 	if len(attrs.GetName()) == 0 {
-		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' (attributes redacted)", nodeName)
 		return authorizer.DecisionNoOpinion, "No Object name found", nil
 	}
 
@@ -227,7 +227,7 @@ func (r *NodeAuthorizer) authorize(nodeName string, startingType vertexType, att
 		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node '%s' and this object", nodeName), nil
 	}
 	if !ok {
-		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' (attributes redacted)", nodeName)
 		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node '%s' and this object", nodeName), nil
 	}
 	return authorizer.DecisionAllow, "", nil


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/32](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/32)

To fix the issue, we need to ensure that sensitive information is not logged in clear text. This can be achieved by obfuscating or redacting sensitive fields in the `attrs` object before logging. Alternatively, we can avoid logging the `attrs` object entirely and log only non-sensitive information, such as the `nodeName` or a sanitized summary of the request.

The best approach is to replace the logging calls that include `attrs` with sanitized or redacted versions of the data. This ensures that sensitive information is not exposed while retaining useful debugging information.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
