### PR TITLE
Potential fix for code scanning alert no. 29: Clear-text logging of sensitive information

### DIFF
--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -168,12 +168,12 @@ func (r *NodeAuthorizer) authorizeStatusUpdate(nodeName string, startingType ver
 	case "update", "patch":
 		// ok
 	default:
-		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %s", nodeName, redactAttributes(attrs))
 		return authorizer.DecisionNoOpinion, "can only get/update/patch this type", nil
 	}
 
 	if attrs.GetSubresource() != "status" {
-		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %s", nodeName, redactAttributes(attrs))
 		return authorizer.DecisionNoOpinion, "can only update status subresource", nil
 	}
 
@@ -200,12 +200,12 @@ func (r *NodeAuthorizer) authorizeReadNamespacedObject(nodeName string, starting
 	case "get", "list", "watch":
 		//ok
 	default:
-		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %s", nodeName, redactAttributes(attrs))
 		return authorizer.DecisionNoOpinion, "can only read resources of this type", nil
 	}
 
 	if len(attrs.GetSubresource()) > 0 {
-		klog.V(2).Infof("NODE DENY: '%s' %#v", nodeName, attrs)
+		klog.V(2).Infof("NODE DENY: '%s' %s", nodeName, redactAttributes(attrs))
 		return authorizer.DecisionNoOpinion, "cannot read subresource", nil
 	}
 	if len(attrs.GetNamespace()) == 0 {
@@ -223,11 +223,11 @@ func (r *NodeAuthorizer) authorize(nodeName string, startingType vertexType, att
 
 	ok, err := r.hasPathFrom(nodeName, startingType, attrs.GetNamespace(), attrs.GetName())
 	if err != nil {
-		klog.V(2).InfoS("NODE DENY", "err", err)
+		klog.V(2).InfoS("NODE DENY", "err", err, "attributes", redactAttributes(attrs))
 		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node '%s' and this object", nodeName), nil
 	}
 	if !ok {
-		klog.V(2).Infof("NODE DENY: '%s' (attributes redacted)", nodeName)
+		klog.V(2).Infof("NODE DENY: '%s' %s", nodeName, redactAttributes(attrs))
 		return authorizer.DecisionNoOpinion, fmt.Sprintf("no relationship found between node '%s' and this object", nodeName), nil
 	}
 	return authorizer.DecisionAllow, "", nil


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/29](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/29)

To fix the issue, we need to ensure that sensitive information in the `attrs` object is either redacted or omitted entirely from the logs. This can be achieved by replacing the direct logging of `attrs` with a sanitized or redacted version. Specifically:
1. Replace instances of `klog.V(2).Infof` that log `attrs` with a version that redacts sensitive fields.
2. Introduce a helper function to sanitize or redact sensitive information from `attrs` before logging.
3. Ensure that all logging calls in the affected functions (`authorizeReadNamespacedObject`, `authorizeStatusUpdate`, etc.) use the sanitized version of `attrs`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
