### PR TITLE
Potential fix for code scanning alert no. 24: Clear-text logging of sensitive information

### DIFF
--- a/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap.go
+++ b/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap.go
@@ -98,7 +98,7 @@ func (t *TokenAuthenticator) AuthenticateToken(ctx context.Context, token string
 	secret, err := t.lister.Get(secretName)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			klog.V(3).Infof("No secret of name %s to match bootstrap bearer token", secretName)
+			klog.V(3).Info("No matching secret found for the provided bootstrap bearer token")
 			return nil, false, nil
 		}
 		return nil, false, err


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/24](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/24)

To fix the issue, we should avoid logging the `secretName` directly. Instead, we can log a generic message that does not include sensitive information. For example, we can log that no matching secret was found without specifying the `secretName`. This ensures that sensitive data is not exposed in the logs while still providing useful debugging information.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
