### PR TITLE
Potential fix for code scanning alert no. 21: Clear-text logging of sensitive information

### DIFF
--- a/pkg/credentialprovider/plugin/plugin.go
+++ b/pkg/credentialprovider/plugin/plugin.go
@@ -287,7 +287,7 @@ func (p *pluginProvider) Provide(image string) credentialprovider.DockerConfig {
 	}
 
 	if err := p.cache.Add(cachedEntry); err != nil {
-		klog.Errorf("Error adding auth entry to cache: %v", err)
+		klog.Error("Error adding auth entry to cache. Sensitive information has been omitted.")
 	}
 
 	return dockerConfig


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/21](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/21)

To address the issue, we will sanitize the error logging on line 290 to ensure that sensitive information, such as `authConfig.Password`, is not included in the logs. Specifically, we will modify the logging statement to avoid directly logging the `err` object if it might contain sensitive data. Instead, we will log a generic error message that does not expose sensitive details.

This fix involves:
1. Replacing the logging statement on line 290 with a sanitized message.
2. Ensuring that no sensitive data is included in the logs, even indirectly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
