### PR TITLE
Potential fix for code scanning alert no. 16: Incomplete regular expression for hostnames

### DIFF
--- a/test/e2e/framework/internal/output/output.go
+++ b/test/e2e/framework/internal/output/output.go
@@ -167,7 +167,7 @@ var klogPrefix = regexp.MustCompile(`(?m)^[IEF][[:digit:]]{4} [[:digit:]]{2}:[[:
 // created by testing.(*T).Run
 //
 //	/nvme/gopath/go/src/testing/testing.go:916 +0x35a
-var testFailureOutput = regexp.MustCompile(`(?m)^k8s.io/kubernetes/test/e2e/framework/internal/output\.TestGinkgoOutput\(.*\n\t.*(\n.*\n\t.*)*`)
+var testFailureOutput = regexp.MustCompile(`(?m)^k8s\.io/kubernetes/test/e2e/framework/internal/output\.TestGinkgoOutput\(.*\n\t.*(\n.*\n\t.*)*`)
 
 // normalizeLocation removes path prefix and function parameters and certain stack entries
 // that we don't care about.


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/16](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/16)

To fix the issue, the unescaped dot (`.`) in the regular expression should be replaced with an escaped dot (`\.`). This ensures that the dot is treated as a literal character, matching only a period (`.`) and not any character. The updated regular expression will correctly match the intended string patterns without unintended matches.

The specific change is in the `testFailureOutput` variable on line 170. The dot before `io` in `k8s.io` should be escaped. Additionally, the use of a raw string literal (enclosed in backticks) can simplify escaping backslashes in the regular expression.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
