### PR TITLE
Potential fix for code scanning alert no. 15: Use of a weak cryptographic key

### DIFF
--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
@@ -572,7 +572,7 @@ func rsaKeySizeFromAlgorithmType(keyType kubeadmapi.EncryptionAlgorithmType) int
 	case kubeadmapi.EncryptionAlgorithmRSA4096:
 		return 4096
 	default:
-		return 0
+		return 2048
 	}
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/15](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/15)

To fix the issue, we will ensure that the RSA key size is never less than 2048 bits, regardless of the input. This can be achieved by modifying the `rsaKeySizeFromAlgorithmType` function to return a minimum key size of 2048 bits for unknown or unrecognized algorithm types, instead of returning `0`. This change will ensure that the `GeneratePrivateKey` function always generates keys with a secure size.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
