### PR TITLE
Potential fix for code scanning alert no. 14: Size computation for allocation may overflow

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
@@ -307,6 +307,11 @@ func addColumns(pos columnAddPosition, table *metav1.Table, columns []metav1.Tab
 // does not expose metadata). It returns an error if the table cannot
 // be decorated.
 func decorateTable(table *metav1.Table, options PrintOptions) error {
+	const maxColumnDefinitions = 1000 // Define a reasonable maximum limit
+	if len(table.ColumnDefinitions) > maxColumnDefinitions {
+		return fmt.Errorf("too many column definitions: %d exceeds maximum allowed %d", len(table.ColumnDefinitions), maxColumnDefinitions)
+	}
+
 	width := len(table.ColumnDefinitions) + len(options.ColumnLabels)
 	if options.WithNamespace {
 		width++


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/14](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/14)

To fix the issue, we need to validate the size of `table.ColumnDefinitions` before using it in arithmetic operations or allocations. Specifically:
1. Introduce a maximum allowable size for `table.ColumnDefinitions` to prevent excessively large values from causing an overflow.
2. Check the length of `table.ColumnDefinitions` against this maximum size and return an error if it exceeds the limit.
3. Ensure that the fix does not alter the existing functionality of the code.

The changes will be made in the `decorateTable` function in `staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
