### PR TITLE
Potential fix for code scanning alert no. 11: Size computation for allocation may overflow

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/transformer.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/transformer.go
@@ -179,6 +179,12 @@ func (t *prefixTransformers) TransformToStorage(ctx context.Context, data []byte
 		logTransformErr(ctx, err, "failed to encrypt data")
 		return nil, err
 	}
+	// Validate the size of the result to prevent overflow during allocation
+	const maxAllowedSize = 64 * 1024 * 1024 // 64 MB
+	if len(result) > maxAllowedSize {
+		return nil, fmt.Errorf("data size exceeds maximum allowed limit of %d bytes", maxAllowedSize)
+	}
+
 	prefixedData := make([]byte, len(transformer.Prefix), len(result)+len(transformer.Prefix))
 	copy(prefixedData, transformer.Prefix)
 	prefixedData = append(prefixedData, result...)


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/11](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/11)

To fix the issue, we need to ensure that the size computation for the allocation does not overflow. This can be achieved by validating the size of `result` before performing the allocation. Specifically:
1. Check if `len(result)` exceeds a predefined maximum safe size (e.g., 64 MB or another appropriate limit for the application).
2. If the size is too large, return an error to prevent further processing.
3. Perform the allocation only after confirming that the size is within safe bounds.

This fix ensures that the allocation is safe and prevents potential runtime panics or unexpected behavior due to overflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
