### PR TITLE
Potential fix for code scanning alert no. 10: Size computation for allocation may overflow

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/aes_extended_nonce.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/aes_extended_nonce.go
@@ -178,6 +178,10 @@ func (t *transformerWithInfo) TransformToStorage(ctx context.Context, data []byt
 		return nil, err
 	}
 
+	// Validate that the combined size does not exceed the maximum value of an int
+	if len(out) > (int(^uint(0) >> 1) - len(t.info)) {
+		return nil, fmt.Errorf("data size too large to process")
+	}
 	outWithInfo := make([]byte, 0, len(out)+len(t.info))
 	outWithInfo = append(outWithInfo, t.info...)
 	outWithInfo = append(outWithInfo, out...)


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/10](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/10)

To fix the issue, we need to ensure that the computation `len(out) + len(t.info)` does not overflow the maximum value of an `int`. This can be achieved by validating the sizes of `out` and `t.info` before performing the addition and allocation. If the combined size exceeds a safe threshold (e.g., the maximum value of an `int`), the function should return an error.

Steps to implement the fix:
1. Add a check before the allocation on line 181 to ensure that `len(out) + len(t.info)` does not exceed the maximum value of an `int`.
2. If the combined size is too large, return an error indicating that the data is too large to process.
3. This fix ensures that the allocation is safe and prevents runtime panics or undefined behavior.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
