### PR TITLE
Potential fix for code scanning alert no. 7: Size computation for allocation may overflow

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/conn.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/wsstream/conn.go
@@ -379,6 +379,9 @@ func (conn *Conn) write(num byte, data []byte) (int, error) {
 	conn.resetTimeout()
 	switch conn.codec {
 	case rawCodec:
+		if len(data) > 64*1024*1024 { // Limit to 64 MB
+			return 0, fmt.Errorf("data size exceeds maximum allowed limit")
+		}
 		frame := make([]byte, len(data)+1)
 		frame[0] = num
 		copy(frame[1:], data)


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/7](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/7)

To fix the issue, we need to ensure that the size of the `data` slice is validated before it is used in the allocation. Specifically:
1. Add a size check for `data` before the `make` call in the `write` function.
2. Define a reasonable maximum size for `data` to prevent overflow. For example, a maximum size of 64 MB (or another appropriate limit based on the application's requirements) can be used.
3. If the size exceeds the limit, return an error to prevent further processing.

This fix ensures that the allocation is safe and prevents potential overflows or runtime panics.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
