### PR TITLE
Potential fix for code scanning alert no. 6: Size computation for allocation may overflow

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
@@ -410,6 +410,9 @@ func (unstructuredJSONScheme) doEncode(obj runtime.Object, w io.Writer) error {
 		for _, i := range t.Items {
 			items = append(items, i.Object)
 		}
+		if len(t.Object) > math.MaxInt-1 {
+			return fmt.Errorf("object size too large: %d", len(t.Object))
+		}
 		listObj := make(map[string]interface{}, len(t.Object)+1)
 		for k, v := range t.Object { // Make a shallow copy
 			listObj[k] = v


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/6](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/6)

To fix the issue, we need to validate the size of `t.Object` before using it in the allocation. Specifically:
1. Check if the length of `t.Object` exceeds a reasonable threshold (e.g., `math.MaxInt-1` or a domain-specific limit).
2. If the size is too large, return an error to prevent the allocation from proceeding.
3. This validation should be added directly before the allocation on line 413.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
