### PR TITLE
Potential fix for code scanning alert no. 5: Size computation for allocation may overflow

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
@@ -40,6 +40,10 @@ func LabelSelectorAsSelector(ps *LabelSelector) (labels.Selector, error) {
 	if len(ps.MatchLabels)+len(ps.MatchExpressions) == 0 {
 		return labels.Everything(), nil
 	}
+	const maxRequirements = 1 << 30 // Maximum safe value for the sum of MatchLabels and MatchExpressions
+	if len(ps.MatchLabels)+len(ps.MatchExpressions) > maxRequirements {
+		return nil, fmt.Errorf("too many label selector requirements: %d", len(ps.MatchLabels)+len(ps.MatchExpressions))
+	}
 	requirements := make([]labels.Requirement, 0, len(ps.MatchLabels)+len(ps.MatchExpressions))
 	for k, v := range ps.MatchLabels {
 		r, err := labels.NewRequirement(k, selection.Equals, []string{v})


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/5](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/5)

To fix the issue, we will add a guard to ensure that the sum of `len(ps.MatchLabels)` and `len(ps.MatchExpressions)` does not exceed a safe threshold before performing the allocation. This threshold will be chosen to prevent integer overflow and ensure that the allocation size is reasonable. If the sum exceeds the threshold, the function will return an error.

**Steps to implement the fix:**
1. Define a maximum safe value for the sum of `len(ps.MatchLabels)` and `len(ps.MatchExpressions)`. For example, we can use a value like `1<<30` (approximately 1 billion), which is far below the maximum value of `int` on 64-bit systems.
2. Add a check before the allocation to ensure that the sum does not exceed this maximum value.
3. If the check fails, return an appropriate error.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
