### PR TITLE
Potential fix for code scanning alert no. 4: Size computation for allocation may overflow

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
@@ -41,6 +41,9 @@ func LabelSelectorAsSelector(ps *LabelSelector) (labels.Selector, error) {
 		return labels.Everything(), nil
 	}
 	const maxRequirements = 1 << 30 // Maximum safe value for the sum of MatchLabels and MatchExpressions
+	if len(ps.MatchLabels) > maxRequirements || len(ps.MatchExpressions) > maxRequirements {
+		return nil, fmt.Errorf("too many label selector requirements: MatchLabels or MatchExpressions exceeds the limit of %d", maxRequirements)
+	}
 	if len(ps.MatchLabels)+len(ps.MatchExpressions) > maxRequirements {
 		return nil, fmt.Errorf("too many label selector requirements: %d", len(ps.MatchLabels)+len(ps.MatchExpressions))
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/4](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/4)

To fix the issue, we will explicitly validate the sizes of `ps.MatchLabels` and `ps.MatchExpressions` before performing the addition. Specifically:
1. We will check if either `len(ps.MatchLabels)` or `len(ps.MatchExpressions)` exceeds `maxRequirements`. If so, we will return an error.
2. This ensures that the addition of these two values cannot overflow, as both values are guaranteed to be within safe bounds.

This fix will be implemented in the `LabelSelectorAsSelector` function in the file `staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
