### PR TITLE
Potential fix for code scanning alert no. 162: Reflected cross-site scripting

### DIFF
--- a/test/images/resource-consumer/resource_consumer_handler.go
+++ b/test/images/resource-consumer/resource_consumer_handler.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"html"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -174,7 +175,7 @@ func (handler *ResourceConsumerHandler) handleBumpMetric(w http.ResponseWriter, 
 
 	go handler.bumpMetric(metric, delta, time.Duration(durationSec)*time.Second)
 	fmt.Fprintln(w, common.BumpMetricAddress[1:])
-	fmt.Fprintln(w, metric, common.MetricNameQuery)
-	fmt.Fprintln(w, delta, common.DeltaQuery)
-	fmt.Fprintln(w, durationSec, common.DurationSecQuery)
+	fmt.Fprintln(w, html.EscapeString(metric), common.MetricNameQuery)
+	fmt.Fprintln(w, html.EscapeString(fmt.Sprintf("%f", delta)), common.DeltaQuery)
+	fmt.Fprintln(w, html.EscapeString(fmt.Sprintf("%d", durationSec)), common.DurationSecQuery)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/162](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/162)

To fix the reflected XSS vulnerability, the user-provided input (`metric`, `delta`, and `durationSec`) must be sanitized or escaped before being written to the HTTP response. In Go, the `html.EscapeString` function from the `html` package can be used to escape special characters in the input, ensuring that any malicious content is rendered harmless in the browser.

The fix involves:
1. Importing the `html` package.
2. Escaping the `metric`, `delta`, and `durationSec` values using `html.EscapeString` before writing them to the response in the `handleBumpMetric` function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
