### PR TITLE
Potential fix for code scanning alert no. 161: Reflected cross-site scripting

### DIFF
--- a/test/images/agnhost/no-snat-test/main.go
+++ b/test/images/agnhost/no-snat-test/main.go
@@ -18,6 +18,7 @@ package nosnat
 
 import (
 	"fmt"
+	"html"
 	"io"
 	"net/http"
 	"os"
@@ -103,7 +104,7 @@ type handler func(http.ResponseWriter, *http.Request)
 func joinErrors(errs []error, sep string) string {
 	strs := make([]string, len(errs))
 	for i, err := range errs {
-		strs[i] = err.Error()
+		strs[i] = html.EscapeString(err.Error())
 	}
 	return strings.Join(strs, sep)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/161](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/161)

To fix the reflected XSS vulnerability, we need to sanitize or escape the error messages before writing them to the HTTP response. The `html.EscapeString` function from the `html` package in Go is a suitable choice for escaping potentially malicious characters in the error messages. This ensures that any user-controlled data included in the error messages is safely rendered in the browser.

The fix involves:
1. Modifying the `joinErrors` function to escape each error message using `html.EscapeString`.
2. Ensuring that the concatenated string returned by `joinErrors` is safe to include in the HTTP response.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
