### PR TITLE
Potential fix for code scanning alert no. 159: Reflected cross-site scripting

### DIFF
--- a/test/images/agnhost/netexec/netexec.go
+++ b/test/images/agnhost/netexec/netexec.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"html"
 	"net/url"
 	"os"
 	"os/exec"
@@ -280,7 +281,7 @@ func echoHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		w.WriteHeader(code)
 	}
-	fmt.Fprintf(w, "%s", msg)
+	fmt.Fprintf(w, "%s", html.EscapeString(msg))
 }
 
 func clientIPHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/159](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/159)

To fix the reflected cross-site scripting vulnerability, the user-provided `msg` parameter must be sanitized or escaped before being written to the HTTP response. The `html.EscapeString` function from the Go standard library should be used to encode special HTML characters in the `msg` string, ensuring that any malicious input is rendered harmless in the browser.

**Steps to fix:**
1. Import the `html` package from the Go standard library.
2. Use `html.EscapeString` to escape the `msg` parameter before writing it to the response on line 283.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
