### PR TITLE
Potential fix for code scanning alert no. 157: Reflected cross-site scripting

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtunnel.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/streamtunnel.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"html"
 	"net"
 	"net/http"
 	"strconv"
@@ -176,7 +177,8 @@ func (w *tunnelingResponseWriter) Write(p []byte) (int, error) {
 		return 0, http.ErrHijacked
 	}
 	w.written = true
-	return w.w.Write(p)
+	escapedData := html.EscapeString(string(p))
+	return w.w.Write([]byte(escapedData))
 }
 
 // WriteHeader is delegated to the stored "http.ResponseWriter".


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/157](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/157)

To fix the issue, we need to ensure that any user-controlled data written to the HTTP response is properly sanitized or escaped. Since the `Write` method in `tunnelingResponseWriter` directly writes the `p` byte slice to the response, we should escape the data if it is intended to be interpreted as text (e.g., HTML or JavaScript). 

The `html.EscapeString` function from the `html` package can be used to escape special characters in the data. However, if the data is binary or not intended to be interpreted as text, escaping might not be necessary. In such cases, additional context about the data's usage is required.

The fix involves:
1. Importing the `html` package.
2. Escaping the `p` byte slice before writing it to the response if it is textual data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
