### PR TITLE
Potential fix for code scanning alert no. 156: Reflected cross-site scripting

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"html"
 	"net"
 	"net/http"
 	"runtime"
@@ -308,7 +309,8 @@ func (rl *respLogger) Write(b []byte) (int, error) {
 	if rl.captureErrorOutput {
 		rl.Addf("logging error output: %q\n", string(b))
 	}
-	return rl.w.Write(b)
+	escapedData := []byte(html.EscapeString(string(b)))
+	return rl.w.Write(escapedData)
 }
 
 // WriteHeader implements http.ResponseWriter.


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/156](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/156)

To fix the issue, we need to ensure that any user-controlled data written to the HTTP response is properly sanitized or escaped. In this case, we can use the `html.EscapeString` function from the `html` package to escape the content of the `b` byte slice before writing it to the response. This will prevent any malicious input from being interpreted as executable code in the browser.

The fix involves:
1. Importing the `html` package in `httplog.go`.
2. Escaping the content of the `b` byte slice using `html.EscapeString` before writing it to the response.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
