### PR TITLE
Potential fix for code scanning alert no. 155: Reflected cross-site scripting

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"html"
 	"runtime"
 	"sync"
 	"time"
@@ -208,7 +209,8 @@ func (tw *baseTimeoutWriter) Write(p []byte) (int, error) {
 		copyHeaders(tw.w.Header(), tw.handlerHeaders)
 		tw.wroteHeader = true
 	}
-	return tw.w.Write(p)
+	escapedData := []byte(html.EscapeString(string(p)))
+	return tw.w.Write(escapedData)
 }
 
 func (tw *baseTimeoutWriter) Flush() {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/155](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/155)

To fix the issue, we need to ensure that any user-controlled data written to the HTTP response is properly sanitized or escaped. Since the `Write` method in `baseTimeoutWriter` directly writes the `p` parameter to the response, we should sanitize `p` before passing it to `tw.w.Write(p)`.

The best approach is to use contextual escaping based on the type of content being written. For example:
- If the content is HTML, use `html.EscapeString` to escape special characters.
- If the content is JSON, ensure it is properly encoded using a JSON encoder.

In this case, we will assume the content is plain text or HTML and use `html.EscapeString` to sanitize the data.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
