### PR TITLE
Potential fix for code scanning alert no. 153: Reflected cross-site scripting

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http"
 	"time"
+	"html"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -75,5 +76,6 @@ func (wt *writeLatencyTracker) Write(bs []byte) (int, error) {
 		request.TrackResponseWriteLatency(wt.ctx, time.Since(startedAt))
 	}()
 
-	return wt.ResponseWriter.Write(bs)
+	escapedData := []byte(html.EscapeString(string(bs)))
+	return wt.ResponseWriter.Write(escapedData)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/153](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/153)

To fix the issue, we need to ensure that any user-controlled data written to the HTTP response is properly sanitized or escaped. In this case, we can use the `html.EscapeString` function from the `html` package to escape the `bs` data before writing it to the response. This will prevent malicious input from being interpreted as executable code by the browser.

The fix involves:
1. Importing the `html` package in `webhook_duration.go`.
2. Escaping the `bs` data using `html.EscapeString` before passing it to `wt.ResponseWriter.Write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
