### PR TITLE
Potential fix for code scanning alert no. 152: Reflected cross-site scripting

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"html"
 	"net"
 	"net/http"
 	"sync"
@@ -245,7 +246,8 @@ func (a *auditResponseWriter) processCode(code int) {
 func (a *auditResponseWriter) Write(bs []byte) (int, error) {
 	// the Go library calls WriteHeader internally if no code was written yet. But this will go unnoticed for us
 	a.processCode(http.StatusOK)
-	return a.ResponseWriter.Write(bs)
+	escapedContent := []byte(html.EscapeString(string(bs)))
+	return a.ResponseWriter.Write(escapedContent)
 }
 
 func (a *auditResponseWriter) WriteHeader(code int) {


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/152](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/152)

To fix the issue, we need to ensure that any user-controlled data written to the HTTP response is properly sanitized or escaped to prevent XSS vulnerabilities. In this case, we can use the `html.EscapeString` function from the `html` package to escape the content of `bs` before writing it to the response. This ensures that any potentially malicious input is rendered harmless in the browser.

The changes will be made in the `Write` method of the `auditResponseWriter` struct in the file `staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go`. Specifically:
1. Import the `html` package to use its `EscapeString` function.
2. Escape the content of `bs` before passing it to `a.ResponseWriter.Write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
