### PR TITLE
Potential fix for code scanning alert no. 18: Bad redirect check

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
@@ -152,9 +152,11 @@ func getRequestOptions(req *http.Request, scope *RequestScope, into runtime.Obje
 
 		p := strings.Join(requestInfo.Parts[startingIndex:], "/")
 
-		// ensure non-empty subpaths correctly reflect a leading slash
-		if len(p) > 0 && !strings.HasPrefix(p, "/") {
-			p = "/" + p
+		// ensure non-empty subpaths correctly reflect a leading slash and disallow "//" or "/\"
+		if len(p) > 0 {
+			if !strings.HasPrefix(p, "/") || (len(p) > 1 && (p[1] == '/' || p[1] == '\\')) {
+				p = "/" + p
+			}
 		}
 
 		// ensure subpaths correctly reflect the presence of a trailing slash on the original request


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/18](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/18)

To fix the issue, the validation logic in the `getRequestOptions` function should be updated to ensure that the constructed path `p` does not start with `//` or `/\`. This can be achieved by extending the existing check on line 156 to include additional conditions for the second character of the path. Specifically:
1. Check that the second character of `p` is not `/` or `\` when the first character is `/`.
2. If the validation fails, prepend a single `/` to the path to ensure it is treated as a relative path on the same host.

The fix should be implemented in the `getRequestOptions` function in `staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
