### PR TITLE
Potential fix for code scanning alert no. 19: Open URL redirect

### DIFF
--- a/test/images/agnhost/liveness/server.go
+++ b/test/images/agnhost/liveness/server.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -61,7 +62,16 @@ func main(cmd *cobra.Command, args []string) {
 			http.Error(w, fmt.Sprintf("invalid redirect: %q", r.URL.Query().Get("loc")), http.StatusBadRequest)
 			return
 		}
-		http.Redirect(w, r, loc, http.StatusFound)
+		// Replace backslashes with forward slashes
+		loc = strings.ReplaceAll(loc, "\\", "/")
+		// Parse the URL
+		target, err := url.Parse(loc)
+		if err != nil || target.Hostname() != "" {
+			http.Error(w, "invalid redirect target", http.StatusBadRequest)
+			return
+		}
+		// Perform the redirect
+		http.Redirect(w, r, target.String(), http.StatusFound)
 	})
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/19](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/19)

To fix the issue, we need to validate the `loc` parameter to ensure it is safe for redirection. A common approach is to restrict redirection to relative URLs or a predefined list of allowed URLs. This prevents attackers from redirecting users to malicious external sites.

In this case, we will:
1. Parse the `loc` parameter as a URL.
2. Replace backslashes with forward slashes to handle browser quirks.
3. Check that the `loc` parameter is a relative URL (i.e., it has no hostname).
4. If the validation fails, return a `400 Bad Request` response.

This ensures that only safe, local redirects are allowed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
