### PR TITLE
Potential fix for code scanning alert no. 17: Bad redirect check

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/transport.go
@@ -147,7 +147,7 @@ func (t *Transport) rewriteURL(url *url.URL, sourceURL *url.URL, sourceRequestHo
 	//      It's the API server's responsibility to rewrite a same-host-and-absolute-path URL and append the
 	//      necessary URL prefix (i.e. /api/v1/namespace/foo/service/bar/proxy/).
 	isDifferentHost := url.Host != "" && url.Host != sourceURL.Host && url.Host != sourceRequestHost
-	isRelative := !strings.HasPrefix(url.Path, "/")
+	isRelative := !(strings.HasPrefix(url.Path, "/") && len(url.Path) > 1 && url.Path[1] != '/' && url.Path[1] != '\\')
 	if isDifferentHost || isRelative {
 		return url.String()
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/17](https://github.com/Git-Hub-Chris/Kubernetes/security/code-scanning/17)

To fix the issue, the check on line 150 should be updated to ensure that the URL path does not start with `//` or `/\`. This can be achieved by extending the condition to check the second character of the path when the first character is a forward slash. Specifically, the condition should verify that the second character is neither a forward slash (`/`) nor a backslash (`\`). This ensures that the URL path is a valid relative path and not an absolute URL pointing to another domain.

The fix involves modifying the `isRelative` condition to include this additional check. No new imports or dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
